### PR TITLE
feat(project): downscale services with up --scale

### DIFF
--- a/client/client_dnswatcher.go
+++ b/client/client_dnswatcher.go
@@ -15,8 +15,8 @@ import (
 // acquire its DHCP lease before recording its DNS address.
 const dnsIPWaitTimeout = 15 * time.Second
 
-// dnsmasqParse parses raw.dnsmasq address lines into a service→[]IP map.
-func dnsmasqParse(raw string) map[string][]string {
+// DNSmasqParse parses raw.dnsmasq address lines into a service->[]IP map.
+func DNSmasqParse(raw string) map[string][]string {
 	result := map[string][]string{}
 	for _, line := range strings.Split(raw, "\n") {
 		line = strings.TrimSpace(line)
@@ -62,7 +62,7 @@ func (c *Client) RegisterDNSWatcher() error {
 	mu := &sync.Mutex{}
 
 	c.AddHookAfter(func(ctx context.Context, action Action, r Resource, _ Options, err error) error {
-		if err != nil || r == nil {
+		if err != nil || !r.IsEnsured() {
 			return err
 		}
 
@@ -148,13 +148,9 @@ func (c *Client) RegisterDNSWatcher() error {
 					}
 
 					if len(iPs) > 0 {
-						cSIPs, ok := servicesIPs[instIncusName]
-						if ok {
-							cSIPs := append(cSIPs, iPs...)
-							servicesIPs[sName] = cSIPs
-						} else {
-							servicesIPs[sName] = iPs
-						}
+						// Aggregate by service name so every replica of a
+						// service is registered under one DNS record.
+						servicesIPs[sName] = append(servicesIPs[sName], iPs...)
 					}
 				}
 

--- a/client/resource_instance.go
+++ b/client/resource_instance.go
@@ -99,6 +99,10 @@ type Instance struct {
 	created   bool
 	Config    InstanceConfig
 
+	// deleteMarked indicates that this instance will be deleted after Ensure(),
+	// this is for down scaling instances.
+	deleteMarked bool
+
 	// conn is this resource's own event-isolated Incus connection, set in
 	// Ensure() (which always runs before any other action) so concurrent
 	// workers never share a *ProtocolIncus. See Client.Connection.
@@ -254,12 +258,27 @@ func (r *Instance) Ensure(ctx context.Context, opts ...Option) error {
 		err = r.ensured()
 		err = r.client.hookAfter(ctx, ActionEnsure, r, options, err)
 
+		if err == nil && r.deleteMarked {
+			if err := r.Stop(ctx, OptionTimeout(options.Timeout), OptionForce()); err != nil {
+				return err
+			}
+
+			if err := r.Delete(ctx); err != nil {
+				return err
+			}
+		}
+
 		return err
 	}
 
 	if !options.Create {
 		err = ErrNotFound.Wrap(err)
 		err = r.client.hookAfter(ctx, ActionEnsure, r, options, err)
+
+		if r.deleteMarked {
+			// Just remove the resource
+			r.client.resources.Remove(r)
+		}
 
 		return err
 	}
@@ -543,18 +562,18 @@ func (r *Instance) attachPostStartDevices(ctx context.Context) error {
 
 // Start starts the instance.
 func (r *Instance) Start(ctx context.Context, opts ...Option) error {
-	if !r.IsEnsured() {
-		return ErrNotEnsured
-	}
-
-	if r.Running() {
-		return nil
-	}
-
 	options := NewOptions(opts...)
 
 	if err := r.client.hookBefore(ctx, ActionStart, r, options, nil); err != nil {
 		return err
+	}
+
+	if !r.IsEnsured() {
+		return r.client.hookAfter(ctx, ActionStart, r, options, ErrNotEnsured)
+	}
+
+	if r.Running() {
+		return r.client.hookAfter(ctx, ActionStart, r, options, nil)
 	}
 
 	return r.client.hookAfter(ctx, ActionStart, r, options, r.start(ctx, options))
@@ -834,18 +853,18 @@ func (r *Instance) secretExists(sPath string, content []byte) bool {
 
 // Stop stops the instance.
 func (r *Instance) Stop(ctx context.Context, opts ...Option) error {
-	if !r.IsEnsured() {
-		return ErrNotEnsured
-	}
-
-	if !r.Running() {
-		return nil
-	}
-
 	options := NewOptions(opts...)
 
 	if err := r.client.hookBefore(ctx, ActionStop, r, options, nil); err != nil {
 		return err
+	}
+
+	if !r.IsEnsured() {
+		return r.client.hookAfter(ctx, ActionStop, r, options, ErrNotEnsured)
+	}
+
+	if !r.Running() {
+		return r.client.hookAfter(ctx, ActionStop, r, options, nil)
 	}
 
 	return r.client.hookAfter(ctx, ActionStop, r, options, r.stop(ctx, options))
@@ -925,16 +944,14 @@ func (r *Instance) setHealthCheckingStopped(stopped bool) error {
 	return nil
 }
 
+// MarkDelete marks a instance to be deleted after Ensure(),
+// this is for down scaling instances.
+func (r *Instance) MarkDelete() {
+	r.deleteMarked = true
+}
+
 // Delete removes the instance from Incus.
 func (r *Instance) Delete(ctx context.Context, opts ...Option) error {
-	if !r.IsEnsured() {
-		r.IncusInstance = nil
-		r.ETag = ""
-
-		r.client.resources.Remove(r)
-		return nil
-	}
-
 	options := NewOptions(opts...)
 
 	if err := r.client.hookBefore(ctx, ActionDelete, r, options, nil); err != nil {
@@ -943,6 +960,14 @@ func (r *Instance) Delete(ctx context.Context, opts ...Option) error {
 
 		r.client.resources.Remove(r)
 		return err
+	}
+
+	if !r.IsEnsured() {
+		r.IncusInstance = nil
+		r.ETag = ""
+
+		r.client.resources.Remove(r)
+		return r.client.hookAfter(ctx, ActionDelete, r, options, nil)
 	}
 
 	op, err := r.conn.DeleteInstance(r.incusName)
@@ -967,18 +992,18 @@ func (r *Instance) Delete(ctx context.Context, opts ...Option) error {
 
 // Log streams the instance console log to the outputHandler.
 func (r *Instance) Log(ctx context.Context, opts ...Option) error {
-	if !r.IsEnsured() {
-		return ErrNotEnsured
-	}
-
-	if !r.Running() {
-		return nil
-	}
-
 	options := NewOptions(opts...)
 
 	if err := r.client.hookBefore(ctx, ActionLog, r, options, nil); err != nil {
 		return err
+	}
+
+	if !r.IsEnsured() {
+		return r.client.hookAfter(ctx, ActionLog, r, options, ErrNotEnsured)
+	}
+
+	if !r.Running() {
+		return r.client.hookAfter(ctx, ActionLog, r, options, nil)
 	}
 
 	err := r.log(ctx, options)

--- a/client/resource_network.go
+++ b/client/resource_network.go
@@ -374,7 +374,7 @@ func (r *Network) UpdateDNSAliases(ownedServices []string, newIPs map[string][]s
 		return fmt.Errorf("reading network %q: %w", r.Name(), err)
 	}
 
-	current := dnsmasqParse(net.Config["raw.dnsmasq"])
+	current := DNSmasqParse(net.Config["raw.dnsmasq"])
 
 	// Delete owned.
 	maps.DeleteFunc(current, func(k string, _ []string) bool {

--- a/client/stack.go
+++ b/client/stack.go
@@ -195,3 +195,26 @@ func (s *Stack) ForAction(action Action) *Stack {
 
 	return result
 }
+
+// ForActionF returns a new stack with resources filtered for the given action,
+// it allows custom filtering with the filter hook.
+func (s *Stack) ForActionF(action Action, filter func(r Resource) bool) *Stack {
+	result := &Stack{
+		client:         s.client,
+		workers:        s.workers,
+		sortDescending: s.sortDescending,
+		seen:           make(map[Resource]struct{}),
+	}
+
+	if filter == nil {
+		filter = func(_ Resource) bool { return true }
+	}
+
+	for _, r := range s.All() {
+		if SupportsAction(r, action) && filter(r) {
+			result.Add(r)
+		}
+	}
+
+	return result
+}

--- a/cmd/incus-compose/e2e_test.go
+++ b/cmd/incus-compose/e2e_test.go
@@ -309,3 +309,121 @@ func TestNormalLifecycle(t *testing.T) {
 		})
 	}
 }
+
+// dnsServiceIPs aggregates the dnsmasq address records for a service across the
+// project's managed networks.
+func dnsServiceIPs(t *testing.T, c *client.Client, networks []string, service string) []string {
+	t.Helper()
+
+	conn, err := c.Connection()
+	require.NoError(t, err)
+
+	var ips []string
+	for _, name := range networks {
+		net, _, err := conn.GetNetwork(name)
+		require.NoError(t, err, "for network %q", name)
+		ips = append(ips, client.DNSmasqParse(net.Config["raw.dnsmasq"])[service]...)
+	}
+	return ips
+}
+
+// TestUpDownscaleRemovesInstancesAndDNS deploys the replicas=3 baseline, then
+// downscales to a single instance with --scale and verifies both the surplus
+// instances and their DNS records are removed while the survivor keeps resolving.
+func TestUpDownscaleRemovesInstancesAndDNS(t *testing.T) {
+	skipLocal(t)
+	t.Parallel()
+
+	ctx := context.Background()
+	pn := t.Name()
+	compose := "../../test/fixtures/nginx-downscale/compose.yaml"
+
+	networks := plannedNetworkNames(t, ctx, pn, compose)
+	require.NotEmpty(t, networks)
+
+	t.Cleanup(func() {
+		_, _, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+	})
+
+	_, _, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	require.NoError(t, err)
+
+	c := projectClient(t, ctx, pn)
+	for _, name := range []string{"web-1", "web-2", "web-3"} {
+		ok, err := c.InstanceExists(name)
+		require.NoError(t, err)
+		require.True(t, ok, "instance %q should exist after up", name)
+	}
+
+	before := dnsServiceIPs(t, c, networks, "web")
+	require.NotEmpty(t, before, "web should have DNS records for 3 replicas")
+
+	_, _, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach", "--scale=web=1")
+	require.NoError(t, err)
+
+	survivor, err := c.InstanceExists("web-1")
+	require.NoError(t, err)
+	require.True(t, survivor, "web-1 should remain after downscale")
+
+	for _, name := range []string{"web-2", "web-3"} {
+		ok, err := c.InstanceExists(name)
+		require.NoError(t, err)
+		require.False(t, ok, "instance %q should be removed after downscale", name)
+	}
+
+	after := dnsServiceIPs(t, c, networks, "web")
+	require.NotEmpty(t, after, "web-1 should still resolve after downscale")
+	require.Less(t, len(after), len(before), "DNS must shed records for removed instances")
+}
+
+// TestUpReconcilesToReplicas verifies docker-parity scaling: a plain `up`
+// reconciles a service to deploy.replicas in both directions. A manual --scale
+// applies only to that invocation; the next plain `up` restores replicas.
+func TestUpReconcilesToReplicas(t *testing.T) {
+	skipLocal(t)
+	t.Parallel()
+
+	ctx := context.Background()
+	pn := t.Name()
+	compose := "../../test/fixtures/nginx-downscale/compose.yaml"
+
+	t.Cleanup(func() {
+		_, _, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+	})
+
+	// Baseline: deploy.replicas=3.
+	_, _, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	require.NoError(t, err)
+
+	c := projectClient(t, ctx, pn)
+	allNames := []string{"web-1", "web-2", "web-3", "web-4", "web-5"}
+	assertCount := func(want int) {
+		t.Helper()
+		for i, name := range allNames {
+			ok, err := c.InstanceExists(name)
+			require.NoError(t, err)
+			require.Equal(t, i < want, ok, "instance %q existence (want %d running)", name, want)
+		}
+	}
+	assertCount(3)
+
+	// Manual downscale to 1.
+	_, _, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach", "--scale=web=1")
+	require.NoError(t, err)
+	assertCount(1)
+
+	// Plain up restores replicas=3 (scales back up).
+	_, _, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	require.NoError(t, err)
+	assertCount(3)
+
+	// Manual upscale to 5.
+	_, _, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach", "--scale=web=5")
+	require.NoError(t, err)
+	assertCount(5)
+
+	// Plain up reconciles back down to replicas=3.
+	_, _, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	require.NoError(t, err)
+	assertCount(3)
+}

--- a/cmd/incus-compose/healthd.go
+++ b/cmd/incus-compose/healthd.go
@@ -389,7 +389,7 @@ func healthdRegisterReloader(c *client.Client, h *client.Instance) error {
 	reloading := false
 
 	c.AddHookAfter(func(ctx context.Context, action client.Action, r client.Resource, _ client.Options, err error) error {
-		if err != nil || r.Kind() != client.KindInstance {
+		if err != nil || !r.IsEnsured() || r.Kind() != client.KindInstance {
 			return err
 		}
 

--- a/cmd/incus-compose/up.go
+++ b/cmd/incus-compose/up.go
@@ -345,7 +345,9 @@ func runUp(ctx context.Context, globalClient *client.GlobalClient, c *client.Cli
 
 	// Start
 	if params.start {
-		if err := stack.ForAction(client.ActionStart).Run(ctx, client.ActionStart, params.stdout, params.stderr, startOptions...); err != nil {
+		startFilter := func(r client.Resource) bool { return r.IsEnsured() }
+
+		if err := stack.ForActionF(client.ActionStart, startFilter).Run(ctx, client.ActionStart, params.stdout, params.stderr, startOptions...); err != nil {
 			c.LogError("Starting resources", "error", err)
 			return errLogged.Wrap(err)
 		}

--- a/docs/compose-compatibility.md
+++ b/docs/compose-compatibility.md
@@ -519,6 +519,11 @@ You can also override replicas via CLI:
 incus-compose up --scale web=5
 ```
 
+`--scale` applies only to that invocation. Like `docker compose up`, a plain `up`
+reconciles each service back to `deploy.replicas` in both directions: it recreates
+instances removed by an earlier `--scale` and tears down extras added by one. Use
+`--scale` (or edit `deploy.replicas`) to change the persistent count.
+
 ### DNS Resolution
 
 After `up`, both the **service name** and the **instance name** resolve inside containers:

--- a/project/instance.go
+++ b/project/instance.go
@@ -35,10 +35,10 @@ func buildPlatform(service types.ServiceConfig) (string, error) {
 // serviceToInstance translates a compose service to an Incus instance.
 // Environment vars become instance config, labels become user metadata.
 // Volumes default to bind mounts for paths starting with / or ., otherwise named volumes.
-func serviceToInstance(c *client.Client, p *types.Project, serviceName string, options *ToStackOptions, index, scale int) ([]client.Resource, error) {
+func serviceToInstance(c *client.Client, p *types.Project, serviceName string, options *ToStackOptions, index, scale int) (*client.Instance, []client.Resource, error) {
 	service, ok := p.Services[serviceName]
 	if !ok {
-		return nil, fmt.Errorf("service %q not found", serviceName)
+		return nil, nil, fmt.Errorf("service %q not found", serviceName)
 	}
 
 	var errs error
@@ -56,7 +56,7 @@ func serviceToInstance(c *client.Client, p *types.Project, serviceName string, o
 			errs = errors.Join(errs, err)
 		}
 		if image == nil {
-			return nil, errs
+			return nil, nil, errs
 		}
 		resources = append(resources, image)
 	}
@@ -86,7 +86,7 @@ func serviceToInstance(c *client.Client, p *types.Project, serviceName string, o
 	}
 
 	if errs != nil {
-		return nil, errs
+		return nil, nil, errs
 	}
 
 	instCfg := &client.InstanceConfig{
@@ -104,13 +104,17 @@ func serviceToInstance(c *client.Client, p *types.Project, serviceName string, o
 		instCfg.Image = image.IncusName()
 	}
 
-	instance, err := c.Resource(client.KindInstance, instanceName(service, index, scale), instCfg)
+	ir, err := c.Resource(client.KindInstance, instanceName(service, index, scale), instCfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	resources = append(resources, instance)
 
-	return resources, nil
+	instance, ok := ir.(*client.Instance)
+	if !ok {
+		return nil, nil, client.ErrUnknown.WithKindName(client.KindInstance, instanceName(service, index, scale))
+	}
+
+	return instance, resources, nil
 }
 
 // instanceConfig builds the Incus instance config map from a compose service.

--- a/project/stack.go
+++ b/project/stack.go
@@ -190,14 +190,20 @@ func (p *Project) ToStack(c *client.Client, stack *client.Stack, opts ...ToStack
 			return fmt.Errorf("found %q a service that does not exists in services, this should never happen", serviceName)
 		}
 
-		// Determine scale: CLI override > deploy.replicas > 1
-		scale := 1
-		if s, ok := options.Scale[serviceName]; ok {
-			scale = s
+		// Determine the desired count: CLI --scale > deploy.replicas > 1.
+		// A plain `up` reconciles to deploy.replicas in both directions, matching
+		// `docker compose up`: a manual --scale applies only to that invocation,
+		// and the next plain `up` restores replicas (scaling up or down).
+		desired := 1
+		if s, ok := options.Scale[service.Name]; ok {
+			desired = s
 		} else if service.Deploy != nil && service.Deploy.Replicas != nil {
-			scale = int(*service.Deploy.Replicas)
+			desired = int(*service.Deploy.Replicas)
 		}
 
+		// Discover existing instances above the desired count so they can be
+		// reconciled away (highest index first) during Ensure.
+		scale := desired
 		for {
 			instanceName := fmt.Sprintf("%s-%d", service.Name, scale+1)
 			if ok, err := c.InstanceExists(instanceName); !ok || err != nil {
@@ -207,14 +213,28 @@ func (p *Project) ToStack(c *client.Client, stack *client.Stack, opts ...ToStack
 			scale = scale + 1
 		}
 
+		instances := []*client.Instance{}
 		for i := 1; i <= scale; i++ {
-			instanceResources, err := serviceToInstance(c, p.Project, serviceName, options, i, scale)
+			instance, instanceResources, err := serviceToInstance(c, p.Project, service.Name, options, i, scale)
 			if err != nil {
 				errs = errors.Join(errs, err)
 				continue
 			}
 
+			resources = append(resources, instance)
 			resources = append(resources, instanceResources...)
+
+			instances = append(instances, instance)
+		}
+
+		// Reconcile down: instances beyond the desired count are marked for
+		// deletion (highest index first) and torn down during Ensure.
+		if len(instances) > desired {
+			slices.Reverse(instances)
+
+			for idx := range len(instances) - desired {
+				instances[idx].MarkDelete()
+			}
 		}
 	}
 

--- a/test/fixtures/nginx-downscale/compose.yaml
+++ b/test/fixtures/nginx-downscale/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  web:
+    image: docker.io/nginx:alpine
+    environment:
+      NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE: 1
+    x-incus:
+      limits.cpu: 1
+    deploy:
+      replicas: 3


### PR DESCRIPTION
Running `up --scale=svc=N` now tears down instances above N. The discovery loop already finds existing instances beyond the requested scale; the surplus is marked for deletion and removed during Ensure.

Also fix a DNS aggregation bug surfaced by the new test: replica IPs were keyed by instance name on lookup but service name on store, so replicas of one service clobbered each other and only the last was resolvable. They are now aggregated under the service record.

fixes #12