### PR TITLE
fix(healthd): use the project network instead of creating its own

### DIFF
--- a/client/resource_instance.go
+++ b/client/resource_instance.go
@@ -83,6 +83,9 @@ type InstanceConfig struct {
 	// status (HealthStatusHealthy, HealthStatusStarting, HealthStatusUnhealthy).
 	// Instance.Start() blocks until all dependencies reach the required status.
 	Dependencies map[string]string
+
+	// Priority if set sets the instance priority to this instead PriorityInstance.
+	Priority int
 }
 
 // GetConfig returns the configuration.
@@ -134,6 +137,10 @@ func newInstance(c *Client, name string, configGetter Config) (*Instance, error)
 	}
 	config = cConfig
 
+	if config.Priority == 0 {
+		config.Priority = PriorityInstance
+	}
+
 	// Set defaults
 	if config.Type == "" {
 		config.Type = incusApi.InstanceTypeContainer
@@ -143,7 +150,7 @@ func newInstance(c *Client, name string, configGetter Config) (*Instance, error)
 	}
 
 	inst := &Instance{
-		BaseResource: NewBaseResource(KindInstance, name, PriorityInstance),
+		BaseResource: NewBaseResource(KindInstance, name, config.Priority),
 		client:       c,
 		incusName:    SanitizeIncusName(name, -1),
 		Config:       *config,
@@ -187,25 +194,23 @@ func (r *Instance) WaitIPs(ctx context.Context, timeout time.Duration) (ips []In
 		return nil, err
 	}
 
-	if !r.Running() {
-		return nil, ErrNotRunning.WithText("in WaitIPs")
-	}
-
 	deadline, cancel := context.WithTimeout(ctx, timeout)
 
 	for {
-		ips, err = r.client.InstanceIPs(r.IncusName())
-		if err == nil {
-			cancel()
-			return ips, nil
-		}
+		r.client.LogDebug("Waiting for IPs", "instance", r)
 
-		r.client.LogDebug("Waiting for IPs", "instance", r, "error", err)
+		if r.Running() {
+			ips, err = r.client.InstanceIPs(r.IncusName())
+			if err == nil {
+				cancel()
+				return ips, nil
+			}
+		}
 
 		select {
 		case <-deadline.Done():
 			cancel()
-			return nil, deadline.Err()
+			return nil, NewError("WaitIPs").Wrap(deadline.Err())
 		case <-time.After(250 * time.Millisecond):
 		}
 	}

--- a/client/stack.go
+++ b/client/stack.go
@@ -105,26 +105,26 @@ func (s *Stack) sort() {
 }
 
 // groupByPriority groups sorted tasks into batches by kind.
-func (s *Stack) groupByKind() [][]Resource {
+func (s *Stack) groupByPriority() [][]Resource {
 	if len(s.resources) == 0 {
 		return nil
 	}
 
 	var batches [][]Resource
-	var currentBatch []Resource
-	currentKind := s.resources[0].Kind()
+	var cBatch []Resource
+	cPriority := s.resources[0].Priority()
 
 	for _, r := range s.resources {
-		if r.Kind() != currentKind {
-			batches = append(batches, currentBatch)
-			currentBatch = nil
-			currentKind = r.Kind()
+		if r.Priority() != cPriority {
+			batches = append(batches, cBatch)
+			cBatch = nil
+			cPriority = r.Priority()
 		}
-		currentBatch = append(currentBatch, r)
+		cBatch = append(cBatch, r)
 	}
 
-	if len(currentBatch) > 0 {
-		batches = append(batches, currentBatch)
+	if len(cBatch) > 0 {
+		batches = append(batches, cBatch)
 	}
 
 	return batches
@@ -165,7 +165,7 @@ func (s *Stack) Run(ctx context.Context, action Action, stdout io.Writer, stderr
 	}
 
 	// Group tasks by priority into batches
-	batches := s.groupByKind()
+	batches := s.groupByPriority()
 
 	// Execute batches in order
 	var errs error

--- a/client/stack_test.go
+++ b/client/stack_test.go
@@ -12,8 +12,8 @@ import (
 // Unit Tests (no Incus required)
 // ----------------------------------------------------------------------------
 
-// TestGroupByKind tests the batch grouping logic without Incus.
-func TestGroupByKind(t *testing.T) {
+// TestGroupByPriority tests the batch grouping logic without Incus.
+func TestGroupByPriority(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name        string
@@ -36,34 +36,34 @@ func TestGroupByKind(t *testing.T) {
 			wantSizes:   []int{1},
 		},
 		{
-			name: "same kind groups together",
+			name: "same priority groups together",
 			tasks: []Resource{
-				newMockResource("a", "", 0, false),
-				newMockResource("b", "", 0, false),
-				newMockResource("c", "", 0, false),
+				newMockResource("a", "", PriorityImage, false),
+				newMockResource("b", "", PriorityImage, false),
+				newMockResource("c", "", PriorityImage, false),
 			},
 			wantBatches: 1,
 			wantSizes:   []int{3},
 		},
 		{
-			name: "different kinds create separate batches",
+			name: "different priorities create separate batches",
 			tasks: []Resource{
-				newMockResource("profile", KindProfile, 0, false),
-				newMockResource("volume", KindStorageVolume, 0, false),
-				newMockResource("instance", KindInstance, 0, false),
+				newMockResource("profile", KindProfile, PriorityProfile, false),
+				newMockResource("volume", KindStorageVolume, PriorityVolume, false),
+				newMockResource("instance", KindInstance, PriorityInstance, false),
 			},
 			wantBatches: 3,
 			wantSizes:   []int{1, 1, 1},
 		},
 		{
-			name: "mixed kinds with multiple per batch",
+			name: "mixed priorities with multiple per batch",
 			tasks: []Resource{
-				newMockResource("profile", KindProfile, 0, false),
-				newMockResource("image", KindImage, 0, false),
-				newMockResource("image2", KindImage, 0, false),
-				newMockResource("volume", KindStorageVolume, 0, false),
-				newMockResource("volume2", KindStorageVolume, 0, false),
-				newMockResource("instance", KindInstance, 0, false),
+				newMockResource("profile", KindProfile, PriorityProfile, false),
+				newMockResource("image", KindImage, PriorityImage, false),
+				newMockResource("image2", KindImage, PriorityImage, false),
+				newMockResource("volume", KindStorageVolume, PriorityVolume, false),
+				newMockResource("volume2", KindStorageVolume, PriorityVolume, false),
+				newMockResource("instance", KindInstance, PriorityInstance, false),
 			},
 			wantBatches: 4,
 			wantSizes:   []int{1, 2, 2, 1},
@@ -76,7 +76,7 @@ func TestGroupByKind(t *testing.T) {
 			stack := NewStack(nil)
 			stack.Add(tc.tasks...)
 
-			batches := stack.groupByKind()
+			batches := stack.groupByPriority()
 
 			require.Len(t, batches, tc.wantBatches)
 
@@ -128,7 +128,7 @@ func TestParallelImageDownload(t *testing.T) {
 		stack.Add(img)
 	}
 
-	batches := stack.groupByKind()
+	batches := stack.groupByPriority()
 	require.Len(t, batches, 1, "all images should be in one batch")
 	require.Len(t, batches[0], 3, "batch should have 3 images")
 

--- a/cmd/incus-compose/healthd.go
+++ b/cmd/incus-compose/healthd.go
@@ -179,6 +179,7 @@ func healthdGetResources(c *client.Client, params healthdParams) (*client.Instan
 			client.HealthKeyPrefix + "daemon": "true",
 		},
 		Resources: []client.Resource{img},
+		Priority:  client.PriorityInstance - 1,
 	}
 
 	instanceConfig.Devices = append(instanceConfig.Devices, client.InstanceDevice{
@@ -204,6 +205,169 @@ func healthdGetResources(c *client.Client, params healthdParams) (*client.Instan
 		return nil, nil, client.ErrUnknown.WithResource(instRes)
 	}
 
+	c.AddHookBefore(func(ctx context.Context, action client.Action, r client.Resource, _ client.Options, err error) error {
+		if err != nil || action != client.ActionEnsure || r.IncusName() != inst.IncusName() {
+			return err
+		}
+
+		ref, err := parseHealthdNetwork(c, params.network)
+		if err != nil {
+			return err
+		}
+
+		var netRes client.Resource
+		switch {
+		case ref.deflt:
+			// The project's own default network. healthd may bring it up before the
+			// rest of the project, so allow creation.
+			netRes, err = c.Resource(client.KindNetwork, ref.name, &client.NetworkConfig{})
+		case ref.project != "" && ref.project != c.Project():
+			// A managed network in another project; must pre-exist (External).
+			var nc *client.Client
+			nc, err = c.Global().EnsureProject(ref.project)
+			if err != nil {
+				return fmt.Errorf("failed to fetch the healthd network: %w", err)
+			}
+
+			netRes, err = nc.Resource(client.KindNetwork, ref.name, &client.NetworkConfig{External: true})
+		default:
+			// A referenced network in this project or a host bridge; must pre-exist.
+			netRes, err = c.Resource(client.KindNetwork, ref.name, &client.NetworkConfig{External: true})
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get a healthd network: %w", err)
+		}
+
+		err = client.RunAction(ctx, netRes, client.ActionEnsure)
+		if err != nil {
+			return fmt.Errorf("failed to ensure a network for healthd: %w", err)
+		}
+
+		network, ok := netRes.(*client.Network)
+		if !ok {
+			return client.ErrUnknown.WithResource(netRes).WithText("failed to cast")
+		}
+
+		inst.Config.Resources = append(inst.Config.Resources, network)
+
+		var incusURL *url.URL
+		if params.incus != nil {
+			incusURL = params.incus
+		} else {
+			if !c.IsRemote() {
+				return errors.New("healthd works only with a https connection, provide one with INCUS_COMPOSE_HEALTHD_INCUS")
+			}
+
+			u, err := c.Global().URL()
+			if err != nil {
+				return fmt.Errorf("failed to get the url: %w", err)
+			}
+
+			if network.IncusNetwork.Config["ipv4.address"] == "" {
+				return fmt.Errorf("ip of network %q is empty", network.Name())
+			}
+
+			ipSplit := strings.Split(network.IncusNetwork.Config["ipv4.address"], "/")
+			ip := net.ParseIP(ipSplit[0])
+			if ip == nil {
+				return fmt.Errorf("result is nil while parsing ip '%v'", ipSplit[0])
+			}
+
+			u.Host = fmt.Sprintf("%s:%s", ip.String(), u.Port())
+			incusURL = u
+		}
+
+		inst.Config.Config["user.healthd.incusurl"] = incusURL.String()
+
+		token, err := healthdCreateToken(c)
+		if err != nil {
+			c.LogWarn("Failed to get a token", "error", err)
+			token = ""
+		}
+
+		if inst.Config.Files == nil {
+			inst.Config.Files = make(map[string]client.InstanceFile)
+		}
+
+		inst.Config.Files["/etc/ic-healthd/token"] = client.InstanceFile{
+			Content: &closingBufferReader{bytes.NewReader([]byte(token))},
+			UID:     -1,
+			GID:     -1,
+			Mode:    0o400,
+			DirMode: 0o700,
+		}
+
+		inst.Config.Devices = append(inst.Config.Devices, client.InstanceDevice{
+			Name: "eth0",
+			Config: client.InstanceDeviceConfig{
+				DeviceType:  client.InstanceDeviceTypeNic,
+				NetworkName: netRes.IncusName(),
+			},
+		})
+
+		flags := []string{fmt.Sprintf(" --incus=%s --project=%s", incusURL.String(), c.IncusProject())}
+		if c.IsDebugging() {
+			flags = append(flags, " --debug")
+		}
+
+		if params.binary != "" {
+			f, err := filepath.Abs(params.binary)
+			if err != nil {
+				return err
+			}
+
+			inst.Config.Files["/usr/local/bin/ic-healthd"] = client.InstanceFile{
+				File:    f,
+				UID:     -1,
+				GID:     -1,
+				Mode:    0o700,
+				DirMode: 0o700,
+			}
+		} else {
+			// c.LogDebug("Setting entrypoint")
+			inst.Config.Config["oci.entrypoint"] = "/usr/local/bin/ic-healthd run" + strings.Join(flags, " ")
+		}
+
+		return err
+	})
+
+	c.AddHookAfter(func(ctx context.Context, action client.Action, r client.Resource, args client.Options, err error) error {
+		if err != nil || action != client.ActionStart || r.IncusName() != inst.IncusName() {
+			return err
+		}
+
+		if params.binary != "" {
+			flags := []string{fmt.Sprintf(" --incus=%s --project=%s", inst.Config.Config["user.healthd.incusurl"], c.IncusProject())}
+			if c.IsDebugging() {
+				flags = append(flags, " --debug")
+			}
+
+			cmd := []string{
+				"sh", "-c",
+				`nohup /usr/local/bin/ic-healthd run` + strings.Join(flags, " ") + `> /var/log/ic-healthd.log 2>&1 &`,
+			}
+			execReq := incusApi.InstanceExecPost{
+				Command:     cmd,
+				WaitForWS:   false,
+				Interactive: false,
+			}
+			conn, err := c.Connection()
+			if err != nil {
+				return err
+			}
+
+			op, err := conn.ExecInstance(inst.IncusName(), execReq, nil)
+			if err != nil {
+				return err
+			}
+			if err := op.Wait(); err != nil {
+				return err
+			}
+		}
+
+		return healthdRegisterReloader(c, inst)
+	})
+
 	return inst, []client.Resource{img, volume}, nil
 }
 
@@ -218,186 +382,25 @@ type healthdNetworkRef struct {
 // parseHealthdNetwork decodes the healthd network selector. An empty value means
 // the project's default network. A "<project>:<network>" value references a
 // managed network that must already exist; anything else is a host bridge name.
-func parseHealthdNetwork(network string) (healthdNetworkRef, error) {
+func parseHealthdNetwork(c *client.Client, network string) (healthdNetworkRef, error) {
 	if network == "" {
 		return healthdNetworkRef{name: "default", deflt: true}, nil
 	}
 
 	if strings.Contains(network, ":") {
-		netProject, netName, _ := strings.Cut(network, ":")
-		if netProject == "" || netName == "" || strings.Contains(netName, ":") {
+		p, n, _ := strings.Cut(network, ":")
+
+		if p == "" {
+			p = c.Project()
+		}
+		if n == "" || strings.Contains(n, ":") {
 			return healthdNetworkRef{}, errors.New("`--healthd-network` is wrong, need something like `<project>:<network>` or `<bridge>`")
 		}
 
-		return healthdNetworkRef{project: netProject, name: netName}, nil
+		return healthdNetworkRef{project: p, name: n}, nil
 	}
 
 	return healthdNetworkRef{name: network}, nil
-}
-
-// healthdUp generates a restricted Incus token, writes it (and optionally a local binary)
-// into the instance via InstanceConfig.Files, ensures (creates) the instance, and starts it.
-func healthdUp(ctx context.Context, c *client.Client, inst *client.Instance, resources []client.Resource, params healthdParams) error {
-	ref, err := parseHealthdNetwork(params.network)
-	if err != nil {
-		return err
-	}
-
-	var netRes client.Resource
-	switch {
-	case ref.deflt:
-		// The project's own default network. healthd may bring it up before the
-		// rest of the project, so allow creation.
-		netRes, err = c.Resource(client.KindNetwork, ref.name, &client.NetworkConfig{})
-	case ref.project != "" && ref.project != c.Project():
-		// A managed network in another project; must pre-exist (External).
-		var nc *client.Client
-		nc, err = c.Global().EnsureProject(ref.project)
-		if err != nil {
-			return fmt.Errorf("failed to fetch the healthd network: %w", err)
-		}
-
-		netRes, err = nc.Resource(client.KindNetwork, ref.name, &client.NetworkConfig{External: true})
-	default:
-		// A referenced network in this project or a host bridge; must pre-exist.
-		netRes, err = c.Resource(client.KindNetwork, ref.name, &client.NetworkConfig{External: true})
-	}
-	if err != nil {
-		return fmt.Errorf("failed to get a healthd network: %w", err)
-	}
-
-	err = client.RunAction(ctx, netRes, client.ActionEnsure, client.OptionCreate())
-	if err != nil {
-		return fmt.Errorf("failed to ensure network %q: %w", netRes, err)
-	}
-
-	network, ok := netRes.(*client.Network)
-	if !ok {
-		return client.ErrUnknown.WithResource(netRes).WithText("failed to cast")
-	}
-
-	var incusURL *url.URL
-	if params.incus != nil {
-		incusURL = params.incus
-	} else {
-		if !c.IsRemote() {
-			return errors.New("healthd works only with a https connection, provide one with INCUS_COMPOSE_HEALTHD_INCUS")
-		}
-
-		u, err := c.Global().URL()
-		if err != nil {
-			return fmt.Errorf("failed to get the url: %w", err)
-		}
-
-		if network.IncusNetwork.Config["ipv4.address"] == "" {
-			return fmt.Errorf("ip of network %q is empty", network.Name())
-		}
-
-		ipSplit := strings.Split(network.IncusNetwork.Config["ipv4.address"], "/")
-		ip := net.ParseIP(ipSplit[0])
-		if ip == nil {
-			return fmt.Errorf("result is nil while parsing ip '%v'", ipSplit[0])
-		}
-
-		u.Host = fmt.Sprintf("%s:%s", ip.String(), u.Port())
-		incusURL = u
-	}
-
-	token, err := healthdCreateToken(c)
-	if err != nil {
-		c.LogWarn("Failed to get a token", "error", err)
-		token = ""
-	}
-
-	if inst.Config.Files == nil {
-		inst.Config.Files = make(map[string]client.InstanceFile)
-	}
-
-	inst.Config.Files["/etc/ic-healthd/token"] = client.InstanceFile{
-		Content: &closingBufferReader{bytes.NewReader([]byte(token))},
-		UID:     -1,
-		GID:     -1,
-		Mode:    0o400,
-		DirMode: 0o700,
-	}
-
-	inst.Config.Devices = append(inst.Config.Devices, client.InstanceDevice{
-		Name: "eth0",
-		Config: client.InstanceDeviceConfig{
-			DeviceType:  client.InstanceDeviceTypeNic,
-			NetworkName: netRes.IncusName(),
-		},
-	})
-
-	flags := []string{fmt.Sprintf(" --incus=%s --project=%s", incusURL.String(), c.IncusProject())}
-	if c.IsDebugging() {
-		flags = append(flags, " --debug")
-	}
-
-	if params.binary != "" {
-		f, err := filepath.Abs(params.binary)
-		if err != nil {
-			return err
-		}
-
-		inst.Config.Files["/usr/local/bin/ic-healthd"] = client.InstanceFile{
-			File:    f,
-			UID:     -1,
-			GID:     -1,
-			Mode:    0o700,
-			DirMode: 0o700,
-		}
-	} else {
-		// c.LogDebug("Setting entrypoint")
-		inst.Config.Config["oci.entrypoint"] = "/usr/local/bin/ic-healthd run" + strings.Join(flags, " ")
-	}
-
-	stack := client.NewStack(c, client.StackWorkers(params.workers))
-	stack.Add(resources...)
-	stack.Add(inst)
-
-	c.LogDebug("Ensure", "resources", stack.All())
-
-	ensureOpts := []client.Option{client.OptionCreate()}
-	if params.pull == "always" {
-		ensureOpts = append(ensureOpts, client.OptionPull())
-	}
-
-	if err := stack.ForAction(client.ActionEnsure).Run(ctx, client.ActionEnsure, params.stdout, params.stderr, ensureOpts...); err != nil {
-		c.LogError("Creating healthd resources", "error", err)
-		return err
-	}
-
-	if err := stack.ForAction(client.ActionStart).Run(ctx, client.ActionStart, params.stdout, params.stderr); err != nil {
-		c.LogError("Starting healthd resources", "error", err)
-		return err
-	}
-
-	if params.binary != "" {
-		cmd := []string{
-			"sh", "-c",
-			`nohup /usr/local/bin/ic-healthd run` + strings.Join(flags, " ") + `> /var/log/ic-healthd.log 2>&1 &`,
-		}
-		execReq := incusApi.InstanceExecPost{
-			Command:     cmd,
-			WaitForWS:   false,
-			Interactive: false,
-		}
-		conn, err := c.Connection()
-		if err != nil {
-			return err
-		}
-
-		op, err := conn.ExecInstance(inst.IncusName(), execReq, nil)
-		if err != nil {
-			return err
-		}
-		if err := op.Wait(); err != nil {
-			return err
-		}
-	}
-
-	return healthdRegisterReloader(c, inst)
 }
 
 // healthdDown stops the instance, deletes it, and revokes its Incus trust certificate.
@@ -903,8 +906,25 @@ func newHealthdUpCommand() *cli.Command {
 				return errLogged.Wrap(err)
 			}
 
-			if err := healthdUp(ctx, c, inst, resources, params); err != nil {
-				globalClient.LogError("Starting healthd", "error", err)
+			stack := client.NewStack(c, client.StackWorkers(params.workers))
+			stack.Add(resources...)
+			stack.Add(inst)
+
+			c.LogDebug("Ensure", "resources", stack.All())
+
+			ensureOpts := []client.Option{client.OptionCreate()}
+			if params.pull == "always" {
+				ensureOpts = append(ensureOpts, client.OptionPull())
+			}
+
+			if err := stack.ForAction(client.ActionEnsure).Run(ctx, client.ActionEnsure, params.stdout, params.stderr, ensureOpts...); err != nil {
+				c.LogError("Creating healthd resources", "error", err)
+				finish(false)
+				return errLogged.Wrap(err)
+			}
+
+			if err := stack.ForAction(client.ActionStart).Run(ctx, client.ActionStart, params.stdout, params.stderr); err != nil {
+				c.LogError("Starting healthd resources", "error", err)
 				finish(false)
 				return errLogged.Wrap(err)
 			}

--- a/cmd/incus-compose/healthd_test.go
+++ b/cmd/incus-compose/healthd_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/lxc/incus-compose/client"
 )
 
 func TestParseHealthdNetwork(t *testing.T) {
@@ -37,11 +40,6 @@ func TestParseHealthdNetwork(t *testing.T) {
 			want:    healthdNetworkRef{name: "incusbr0"},
 		},
 		{
-			name:    "missing project errors",
-			network: ":default",
-			wantErr: true,
-		},
-		{
 			name:    "missing network errors",
 			network: "default:",
 			wantErr: true,
@@ -53,11 +51,12 @@ func TestParseHealthdNetwork(t *testing.T) {
 		},
 	}
 
+	c := client.NewOfflineClient(context.Background(), "default")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := parseHealthdNetwork(tt.network)
+			got, err := parseHealthdNetwork(c, tt.network)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/cmd/incus-compose/up.go
+++ b/cmd/incus-compose/up.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"io"
 	"net/url"
 	"strconv"
 	"strings"
@@ -119,6 +118,10 @@ func newUpCommand() *cli.Command {
 				client.EnsureProjectWithCreate(),
 				client.EnsureProjectWithConfig(p.ProjectConfig()),
 			)
+			defer func() {
+				_ = c.Done()
+			}()
+
 			if err != nil {
 				globalClient.LogError("Getting the incus project", "error", err)
 				return errLogged.Wrap(err)
@@ -141,6 +144,86 @@ func newUpCommand() *cli.Command {
 			usesHealthd := !cmd.Bool("no-healthd")
 			if !healthdInUseByProject(p) {
 				usesHealthd = false
+			}
+
+			buildMode := client.BuildAuto
+			if cmd.Bool("build") {
+				buildMode = client.BuildForce
+			} else if cmd.Bool("no-build") {
+				buildMode = client.BuildNever
+			}
+			buildInfo := client.BuildInfo{
+				Mode:             buildMode,
+				PreferredBuilder: cmd.String("builder"),
+			}
+
+			runOptions := []client.Option{client.OptionTimeout(cmd.Duration("timeout"))}
+			// With --no-deps the linked services are out of scope, so don't wait on
+			// healthd dependency conditions (depends_on: service_healthy) that maybe can't
+			// be satisfied because those dependencies were never started.
+			if !usesHealthd || cmd.Bool("no-deps") {
+				runOptions = append(runOptions, client.OptionNoHealthd())
+			}
+
+			if cmd.Bool("recreate") {
+				stack := client.NewStack(c, client.StackWorkers(cmd.Root().Int("workers")))
+				toStackOpts := []project.ToStackOption{}
+				toStackOpts = append(toStackOpts, project.ToStackNoImages(), project.ToStackReverse(), project.ToStackOnlyServices(cmd.Args().Slice()))
+				if !cmd.Bool("no-deps") {
+					toStackOpts = append(toStackOpts, project.ToStackWithDeps())
+				}
+
+				scale := parseScale(cmd.StringSlice("scale"))
+				if len(scale) > 0 {
+					toStackOpts = append(toStackOpts, project.ToStackScale(scale))
+				}
+				err := p.ToStack(c, stack, toStackOpts...)
+				if err != nil {
+					c.LogError("Creating the stack in reCreate", "error", err)
+					return errLogged.Wrap(err)
+				}
+
+				c.LogDebug("Ensure", "resources", stack.All())
+
+				recreateOptions := append(runOptions, client.OptionForce())
+
+				// Ensure without create for "recreate" (resolution only, no progress).
+				if err := stack.ForAction(client.ActionEnsure).Run(ctx, client.ActionEnsure, cmd.Root().Writer, cmd.Root().ErrWriter); err != nil {
+					c.LogDebug("Ensuring for reCreate", "error", err)
+				} else {
+					// Stop
+					errStop := stack.ForAction(client.ActionStop).Run(ctx, client.ActionStop, cmd.Root().Writer, cmd.Root().ErrWriter, recreateOptions...)
+					if errStop != nil {
+						c.LogDebug("Stopping resources", "error", errStop)
+					}
+
+					// Delete
+					deleteStack := stack.ForAction(client.ActionDelete)
+					c.LogDebug("Recreate delete", "resources", deleteStack.All())
+					errDel := deleteStack.Run(ctx, client.ActionDelete, cmd.Root().Writer, cmd.Root().ErrWriter, recreateOptions...)
+					if errDel != nil {
+						c.LogDebug("Deleting resources", "error", errDel)
+					}
+				}
+
+				// Start fresh after recreate
+				c.ResetResources()
+			}
+
+			stack := client.NewStack(c, client.StackWorkers(cmd.Root().Int("workers")))
+			toStackOpts := []project.ToStackOption{}
+			toStackOpts = append(toStackOpts, project.ToStackStorageVolumes(), project.ToStackOnlyServices(cmd.Args().Slice()))
+			if !cmd.Bool("no-deps") {
+				toStackOpts = append(toStackOpts, project.ToStackWithDeps())
+			}
+			scale := parseScale(cmd.StringSlice("scale"))
+			if len(scale) > 0 {
+				toStackOpts = append(toStackOpts, project.ToStackScale(scale))
+			}
+			err = p.ToStack(c, stack, toStackOpts...)
+			if err != nil {
+				c.LogError("Adding the project to a stack", "error", err)
+				return errLogged.Wrap(err)
 			}
 
 			if usesHealthd {
@@ -186,72 +269,48 @@ func newUpCommand() *cli.Command {
 					return errLogged.Wrap(err)
 				}
 
-				if err := healthdUp(ctx, c, inst, resources, hparams); err != nil {
-					globalClient.LogError("Starting healthd", "error", err)
+				stack.Add(resources...)
+				stack.Add(inst)
+			}
 
-					finish(err == nil)
+			c.LogDebug("Ensure", "resources", stack.All())
+
+			// Ensure with create. --pull=always refreshes cached images from registry.
+			// policy and missing only use the local cache (pull if not present).
+			startOptions := append(runOptions, client.OptionCreate())
+			if cmd.String("pull") == "always" {
+				startOptions = append(startOptions, client.OptionPull())
+			}
+			if buildInfo.Mode != client.BuildAuto || buildInfo.PreferredBuilder != "" {
+				startOptions = append(startOptions, client.OptionBuild(buildInfo))
+			}
+			if cmd.Duration("dependency-timeout") > 0 {
+				startOptions = append(startOptions, client.OptionDependencyTimeout(cmd.Duration("dependency-timeout")))
+			}
+
+			err = stack.ForAction(client.ActionEnsure).Run(ctx, client.ActionEnsure, cmd.Root().Writer, cmd.Root().ErrWriter, startOptions...)
+			if err != nil {
+				c.LogError("Ensuring resources", "error", err)
+				return errLogged.Wrap(err)
+			}
+
+			// Start
+			if !cmd.Bool("no-start") {
+				startFilter := func(r client.Resource) bool { return r.IsEnsured() }
+
+				if err := stack.ForActionF(client.ActionStart, startFilter).Run(ctx, client.ActionStart, cmd.Root().Writer, cmd.Root().ErrWriter, startOptions...); err != nil {
+					c.LogError("Starting resources", "error", err)
 					return errLogged.Wrap(err)
 				}
 			}
 
-			buildMode := client.BuildAuto
-			if cmd.Bool("build") {
-				buildMode = client.BuildForce
-			} else if cmd.Bool("no-build") {
-				buildMode = client.BuildNever
-			}
-			buildInfo := client.BuildInfo{
-				Mode:             buildMode,
-				PreferredBuilder: cmd.String("builder"),
-			}
-
-			params := upParams{
-				reCreate:          cmd.Bool("recreate"),
-				start:             !cmd.Bool("no-start"),
-				healthd:           usesHealthd,
-				deps:              !cmd.Bool("no-deps"),
-				services:          cmd.Args().Slice(),
-				pull:              cmd.String("pull"),
-				build:             buildInfo,
-				timeout:           cmd.Duration("timeout"),
-				dependencyTimeout: cmd.Duration("dependency-timeout"),
-				scale:             parseScale(cmd.StringSlice("scale")),
-				stdout:            cmd.Root().Writer,
-				stderr:            cmd.Root().ErrWriter,
-				workers:           cmd.Root().Int("workers"),
-			}
-			if err := runUp(ctx, globalClient, c, p, params); err != nil {
-				_ = c.Done()
-
-				finish(err == nil)
-				return err
-			}
 			_ = c.Done()
 
 			finish(err == nil)
 
-			c.LogDebug("All done")
 			return nil
 		},
 	}
-}
-
-// upParams holds the parsed arguments for an up run.
-// services is the raw service filter (empty means all services).
-type upParams struct {
-	services          []string
-	start             bool
-	healthd           bool
-	deps              bool
-	reCreate          bool
-	pull              string
-	build             client.BuildInfo
-	timeout           time.Duration
-	dependencyTimeout time.Duration
-	scale             map[string]int
-	stdout            io.Writer
-	stderr            io.Writer
-	workers           int
 }
 
 // parseScale parses --scale flags of the form "service=num".
@@ -266,120 +325,4 @@ func parseScale(values []string) map[string]int {
 		}
 	}
 	return scaleOverrides
-}
-
-// runUp creates (and optionally starts) the services of a loaded project.
-func runUp(ctx context.Context, globalClient *client.GlobalClient, c *client.Client, p *project.Project, params upParams) error {
-	runOptions := []client.Option{client.OptionTimeout(params.timeout)}
-	// With --no-deps the linked services are out of scope, so don't wait on
-	// healthd dependency conditions (depends_on: service_healthy) that maybe can't
-	// be satisfied because those dependencies were never started.
-	if !params.healthd || !params.deps {
-		runOptions = append(runOptions, client.OptionNoHealthd())
-	}
-
-	// defer func() {
-	// 	if c.Errors() != nil {
-	// 		c.Logger().ErrorContext(c.Ctx, "Error(s) during up", "error", c.Errors())
-	// 		if c.IsDebugging() {
-	// 			c.Logger().WarnContext(c.Ctx, "Wont rollback in debug")
-	// 		} else {
-	// 			err := c.Rollback(0)
-	// 			if err != nil {
-	// 				c.Logger().ErrorContext(c.Ctx, "During rollback", "error", err)
-	// 			}
-	// 		}
-	// 	}
-	// }()
-
-	if params.reCreate {
-		stack := client.NewStack(c, client.StackWorkers(params.workers))
-		toStackOpts := []project.ToStackOption{}
-		toStackOpts = append(toStackOpts, project.ToStackNoImages(), project.ToStackReverse(), project.ToStackOnlyServices(params.services))
-		if params.deps {
-			toStackOpts = append(toStackOpts, project.ToStackWithDeps())
-		}
-		if len(params.scale) > 0 {
-			toStackOpts = append(toStackOpts, project.ToStackScale(params.scale))
-		}
-		err := p.ToStack(c, stack, toStackOpts...)
-		if err != nil {
-			c.LogError("Creating the stack in reCreate", "error", err)
-			return errLogged.Wrap(err)
-		}
-
-		c.LogDebug("Ensure", "resources", stack.All())
-
-		recreateOptions := append(runOptions, client.OptionForce())
-
-		// Ensure without create for "recreate" (resolution only, no progress).
-		if err := stack.ForAction(client.ActionEnsure).Run(ctx, client.ActionEnsure, params.stdout, params.stderr); err != nil {
-			c.LogDebug("Ensuring for reCreate", "error", err)
-		} else {
-			// Stop
-			errStop := stack.ForAction(client.ActionStop).Run(ctx, client.ActionStop, params.stdout, params.stderr, recreateOptions...)
-			if errStop != nil {
-				c.LogDebug("Stopping resources", "error", errStop)
-			}
-
-			// Delete
-			deleteStack := stack.ForAction(client.ActionDelete)
-			c.LogDebug("Recreate delete", "resources", deleteStack.All())
-			errDel := deleteStack.Run(ctx, client.ActionDelete, params.stdout, params.stderr, recreateOptions...)
-			if errDel != nil {
-				c.LogDebug("Deleting resources", "error", errDel)
-			}
-		}
-
-		// Start fresh after recreate
-		c.ResetResources()
-	}
-
-	stack := client.NewStack(c, client.StackWorkers(params.workers))
-	toStackOpts := []project.ToStackOption{}
-	toStackOpts = append(toStackOpts, project.ToStackStorageVolumes(), project.ToStackOnlyServices(params.services))
-	if params.deps {
-		toStackOpts = append(toStackOpts, project.ToStackWithDeps())
-	}
-	if len(params.scale) > 0 {
-		toStackOpts = append(toStackOpts, project.ToStackScale(params.scale))
-	}
-	err := p.ToStack(c, stack, toStackOpts...)
-	if err != nil {
-		c.LogError("Adding the project to a stack", "error", err)
-		return errLogged.Wrap(err)
-	}
-
-	c.LogDebug("Ensure", "resources", stack.All())
-
-	// Ensure with create. --pull=always refreshes cached images from registry.
-	// policy and missing only use the local cache (pull if not present).
-	startOptions := append(runOptions, client.OptionCreate())
-	if params.pull == "always" {
-		startOptions = append(startOptions, client.OptionPull())
-	}
-	if params.build.Mode != client.BuildAuto || params.build.PreferredBuilder != "" {
-		startOptions = append(startOptions, client.OptionBuild(params.build))
-	}
-	if params.dependencyTimeout > 0 {
-		startOptions = append(startOptions, client.OptionDependencyTimeout(params.dependencyTimeout))
-	}
-
-	err = stack.ForAction(client.ActionEnsure).Run(ctx, client.ActionEnsure, params.stdout, params.stderr, startOptions...)
-	if err != nil {
-		c.LogError("Ensuring resources", "error", err)
-		return errLogged.Wrap(err)
-	}
-
-	// Start
-	if params.start {
-		startFilter := func(r client.Resource) bool { return r.IsEnsured() }
-
-		if err := stack.ForActionF(client.ActionStart, startFilter).Run(ctx, client.ActionStart, params.stdout, params.stderr, startOptions...); err != nil {
-			c.LogError("Starting resources", "error", err)
-			return errLogged.Wrap(err)
-		}
-	}
-
-	return nil
 }

--- a/docs/healthd.md
+++ b/docs/healthd.md
@@ -149,14 +149,15 @@ x-incus-compose:
     # Incus API endpoint healthd connects to.
     # Default: the bridge IP of `network` below, with the port incus-compose
     # itself connected on.
-    incus: https://:8443
+    incus: https://<ip-of-the-projects-bridge>:8443
     # `<project>:<network>` for a managed network, or a plain bridge name.
+    # We assume the current project if you leave the first part empty.
     # Default: the `default` network of the current project.
-    network: default:default
+    network: :default
 ```
 
-| Flag                | Environment variable           | Compose key                       |
-| ------------------- | ------------------------------ | --------------------------------- |
+| Flag                | Environment variable            | Compose key                       |
+| ------------------- | ------------------------------- | --------------------------------- |
 | `--healthd-incus`   | `INCUS_COMPOSE_HEALTHD_INCUS`   | `x-incus-compose.healthd.incus`   |
 | `--healthd-network` | `INCUS_COMPOSE_HEALTHD_NETWORK` | `x-incus-compose.healthd.network` |
 
@@ -186,12 +187,12 @@ reach Incus over that bridge.
 
 ### Combinations
 
-| `network`                    | `incus` | Behavior                                      |
-| ---------------------------- | ------- | --------------------------------------------- |
-| default                      | empty   | Project bridge IP + client port (the default) |
-| default                      | URL     | Project bridge for the NIC, pinned endpoint   |
-| bridge / `project:network`   | empty   | Different bridge, auto-detected IP            |
-| bridge / `project:network`   | URL     | Different bridge, pinned endpoint             |
+| `network`                  | `incus` | Behavior                                      |
+| -------------------------- | ------- | --------------------------------------------- |
+| default                    | empty   | Project bridge IP + client port (the default) |
+| default                    | URL     | Project bridge for the NIC, pinned endpoint   |
+| bridge / `project:network` | empty   | Different bridge, auto-detected IP            |
+| bridge / `project:network` | URL     | Different bridge, pinned endpoint             |
 
 ## Security
 

--- a/test/fixtures/nginx-proxy/compose.yaml
+++ b/test/fixtures/nginx-proxy/compose.yaml
@@ -1,5 +1,9 @@
 name: nginx-proxy
 
+x-incus-compose:
+  healthd:
+    network: :backend
+
 services:
   nginx:
     image: docker.io/nginxinc/nginx-unprivileged:alpine

--- a/test/snapshots/e2e/TestListSnapshots-list_json
+++ b/test/snapshots/e2e/TestListSnapshots-list_json
@@ -6,6 +6,7 @@
     "incus_name": "ic-uf62fvkwl4",
     "image": "",
     "status": "Exists",
+    "health": "",
     "addresses": []
   },
   {
@@ -15,6 +16,7 @@
     "incus_name": "web-1",
     "image": "docker.io/library/nginx:alpine",
     "status": "Running",
+    "health": "Unknown",
     "addresses": [
       ""
     ]

--- a/test/snapshots/e2e/TestListSnapshots-list_table
+++ b/test/snapshots/e2e/TestListSnapshots-list_table
@@ -1,4 +1,4 @@
-KIND      NAME     INCUSNAME      IMAGE                           STATUS   ADDRESSES
-network   default  ic-uf62fvkwl4                                  Exists   
-instance  web      web-1          docker.io/library/nginx:alpine  Running  
+KIND      NAME     INCUSNAME      IMAGE                           STATUS   HEALTH   ADDRESSES
+network   default  ic-uf62fvkwl4                                  Exists            
+instance  web      web-1          docker.io/library/nginx:alpine  Running  Unknown  
 

--- a/test/snapshots/e2e/TestListSnapshots-list_yaml
+++ b/test/snapshots/e2e/TestListSnapshots-list_yaml
@@ -4,6 +4,7 @@
   incus_name: ic-uf62fvkwl4
   image: ""
   status: Exists
+  health: ""
   addresses: []
 - kind: instance
   name: web
@@ -11,6 +12,7 @@
   incus_name: web-1
   image: docker.io/library/nginx:alpine
   status: Running
+  health: Unknown
   addresses:
     - 
 

--- a/test/snapshots/project/TestConfigSnapshots-nginx-proxy_yaml
+++ b/test/snapshots/project/TestConfigSnapshots-nginx-proxy_yaml
@@ -73,3 +73,6 @@ networks:
   frontend:
     name: nginx-proxy_frontend
     driver: bridge
+x-incus-compose:
+  healthd:
+    network: :backend


### PR DESCRIPTION
Run the sidecar inside the project stack rather than a separate one: give it PriorityInstance-1 so it ensures before regular instances, and attach the project's network as a sub-resource via a before-ensure hook. Group stack batches by priority instead of kind so the sidecar lands in its own batch.