### PR TITLE
feat(project): add default labels, fixes #56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Version numbering moved from `0.0.1` to `1.0.0` at beta11 (1.0.0 is the intended
 final version), and the beta suffix gained a dot (`beta.16`) from beta.16 onward
 for correct semver ordering. Headings below preserve each release's announced form.
 
+## [1.0.0-rc.2] - 2026-07-08
+
+Second release candidate cause of the breaking `user.` -> `user.label.` change below.
+
+### Changed
+
+- Labels now have a `user.label.` prefix instead `user.` only, to not conflict with
+  other user settings.
+
 ## [1.0.0-rc.1] - 2026-07-07
 
 First release candidate. File pushes move to the Incus SFTP API, `command` now

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -22,9 +22,6 @@ const (
 	HealthStoppedKey = HealthKeyPrefix + "stopped"
 )
 
-// IncusComposePrefix is the instance config prefix for incus-compose variables.
-const IncusComposePrefix = "user.incus-compose."
-
 // Kind identifies a resource type.
 type Kind string
 

--- a/client/resource_instance.go
+++ b/client/resource_instance.go
@@ -322,7 +322,7 @@ func (r *Instance) Ensure(ctx context.Context, opts ...Option) error {
 
 func (r *Instance) ensured() error {
 	if r.Config.Image == "" {
-		if alias, ok := r.IncusInstance.Config[IncusComposePrefix+"image_alias"]; ok {
+		if alias, ok := r.IncusInstance.Config["user.image_alias"]; ok {
 			r.Config.Image = alias
 		} else {
 			r.Config.Image = r.client.ResolveImageFingerprint(r.IncusInstance.Config["volatile.base_image"])
@@ -396,10 +396,7 @@ func (r *Instance) create(ctx context.Context, opts ...Option) error {
 	}
 
 	// Store the image name
-	config[IncusComposePrefix+"image_alias"] = image.IncusName()
-
-	// Store the service name
-	config[IncusComposePrefix+"service_name"] = r.ServiceName()
+	config["user.image_alias"] = image.IncusName()
 
 	// Build devices map after volumes are resolved.
 	devices, err := r.buildDevices()

--- a/project/config_snapshot_test.go
+++ b/project/config_snapshot_test.go
@@ -173,6 +173,10 @@ func TestConfigSnapshots(t *testing.T) {
 			Fixture: "with-env/compose.yaml",
 		},
 		{
+			Name:    "with-labels_yaml",
+			Fixture: "with-labels/compose.yaml",
+		},
+		{
 			Name:    "with-tmpfs_yaml",
 			Fixture: "with-tmpfs/compose.yaml",
 		},

--- a/project/instance.go
+++ b/project/instance.go
@@ -14,6 +14,9 @@ import (
 	"github.com/lxc/incus-compose/client"
 )
 
+// labelIncusComposePrefix is the instance config prefix for incus-compose labels.
+const labelIncusComposePrefix = "user.label.incus-compose."
+
 type xICInstanceVolume struct {
 	Seed bool `mapstructure:"seed"`
 }
@@ -43,7 +46,7 @@ func serviceToInstance(c *client.Client, p *types.Project, serviceName string, o
 	var errs error
 	resources := []client.Resource{}
 
-	config, err := instanceConfig(service)
+	config, err := instanceConfig(service, p.Name)
 	if err != nil {
 		errs = errors.Join(errs, err)
 	}
@@ -144,7 +147,7 @@ func serviceToInstance(c *client.Client, p *types.Project, serviceName string, o
 // instanceConfig builds the Incus instance config map from a compose service.
 // Environment vars become environment.* keys, labels become user.* keys, and
 // restart/resource/healthcheck settings and raw x-incus options are merged in.
-func instanceConfig(service types.ServiceConfig) (map[string]string, error) {
+func instanceConfig(service types.ServiceConfig, projectName string) (map[string]string, error) {
 	config := make(map[string]string, len(service.Environment)+len(service.Labels))
 
 	// Environment variables
@@ -156,8 +159,11 @@ func instanceConfig(service types.ServiceConfig) (map[string]string, error) {
 
 	// Labels as user config
 	for key, val := range service.Labels {
-		config["user."+key] = val
+		config["user.label."+key] = val
 	}
+
+	config[labelIncusComposePrefix+"service"] = service.Name
+	config[labelIncusComposePrefix+"project"] = projectName
 
 	// Privileged.
 	if service.Privileged {

--- a/project/instance_test.go
+++ b/project/instance_test.go
@@ -179,12 +179,12 @@ func TestInstanceConfig(t *testing.T) {
 		},
 	}
 
-	config, err := instanceConfig(service)
+	config, err := instanceConfig(service, "")
 	require.NoError(t, err)
 
 	assert.Equal(t, "bar", config["environment.FOO"])
 	assert.NotContains(t, config, "environment.SKIP")
-	assert.Equal(t, "x", config["user.com.example"])
+	assert.Equal(t, "x", config["user.label.com.example"])
 	// The entrypoint is assembled in the client layer (image entrypoint +
 	// AppendEntrypoint), so instanceConfig no longer emits oci.entrypoint.
 	assert.NotContains(t, config, "oci.entrypoint")
@@ -200,10 +200,16 @@ func TestInstanceConfig(t *testing.T) {
 func TestInstanceConfigMinimal(t *testing.T) {
 	t.Parallel()
 
-	config, err := instanceConfig(types.ServiceConfig{Name: "web"})
+	config, err := instanceConfig(types.ServiceConfig{Name: "web"}, "project1")
 	require.NoError(t, err)
 	// Only the default restart policy is applied.
-	assert.Equal(t, map[string]string{"boot.autostart": "false", client.HealthStatusKey: client.HealthStatusUnknown, "raw.lxc": "lxc.start.delay = 1\n"}, config)
+	assert.Equal(t, map[string]string{
+		"boot.autostart":                   "false",
+		client.HealthStatusKey:             client.HealthStatusUnknown,
+		"raw.lxc":                          "lxc.start.delay = 1\n",
+		"user.label.incus-compose.project": "project1",
+		"user.label.incus-compose.service": "web",
+	}, config)
 }
 
 func TestInstanceConfigXIncusOverrides(t *testing.T) {
@@ -212,7 +218,7 @@ func TestInstanceConfigXIncusOverrides(t *testing.T) {
 	proj, err := New().Load(context.Background(), LoadWorkingDir(fixturePath("with-incus-options")))
 	require.NoError(t, err)
 
-	config, err := instanceConfig(proj.Services["web"])
+	config, err := instanceConfig(proj.Services["web"], "")
 	require.NoError(t, err)
 	assert.Equal(t, "1024MB", config["limits.memory"])
 	assert.Equal(t, "2", config["limits.cpu"])

--- a/test/fixtures/with-labels/compose.yaml
+++ b/test/fixtures/with-labels/compose.yaml
@@ -1,0 +1,7 @@
+services:
+  web:
+    image: docker.io/nginxinc/nginx-unprivileged:alpine
+    labels:
+      caddy: whoami.example.com
+      caddy.reverse_proxy: "{{upstreams 80}}}"
+      traefik.http.routers.web.rule: "Host(`whoami.example.com`)"

--- a/test/snapshots/project/TestConfigSnapshots-with-labels_yaml
+++ b/test/snapshots/project/TestConfigSnapshots-with-labels_yaml
@@ -1,0 +1,13 @@
+name: with-labels
+services:
+  web:
+    image: docker.io/nginxinc/nginx-unprivileged:alpine
+    labels:
+      caddy: whoami.example.com
+      caddy.reverse_proxy: '{{upstreams 80}}}'
+      traefik.http.routers.web.rule: Host(`whoami.example.com`)
+    networks:
+      default: null
+networks:
+  default:
+    name: with-labels_default


### PR DESCRIPTION
add `user.incus-compose.project` and `user.incus-compose.service`.

Labels mapping itself was already there:

```yaml
config:
  user.label.caddy: whoami.example.com
  user.label.caddy.reverse_proxy: '{{upstreams 80}}}'
  user.image_alias: docker.io/nginxinc/nginx-unprivileged:alpine
  user.label.incus-compose.project: with-labels
  user.label.incus-compose.service: web
  user.label.traefik.http.routers.web.rule: Host(`whoami.example.com`)
```