### PR TITLE
feat(project): add support for configs

### DIFF
--- a/cmd/incus-compose/e2e_test.go
+++ b/cmd/incus-compose/e2e_test.go
@@ -816,6 +816,47 @@ func TestE2EUpDownWithConfigs(t *testing.T) {
 	runE2ETests(t, ctx, pn, tests)
 }
 
+func TestE2EUpDownWithConfigsVerifyFiles(t *testing.T) {
+	t.Parallel()
+	skipLocal(t)
+	skipE2E(t)
+
+	ctx := context.Background()
+	pn := t.Name()
+	compose := "../../test/fixtures/with-configs/compose.yaml"
+
+	t.Cleanup(func() {
+		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+	})
+
+	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	require.NoError(t, err)
+
+	// Verify each config file exists with correct perms/ownership
+	checks := []struct {
+		path  string
+		perms string
+		uid   string
+		gid   string
+	}{
+		{"/app_config", "-rw-r--r--", "0", "0"},                  // default mode 0644
+		{"/db_config", "-rw-r--r--", "0", "0"},                  // default mode 0644
+		{"/etc/nginx/nginx.conf", "-rw-r-----", "101", "101"},   // explicit 0640 + uid/gid
+	}
+
+	for _, tc := range checks {
+		stdout, err := runCommand(t, ctx, pn, "-f", compose, "exec", "--no-tty", "app",
+			"--", "ls", "-ln", tc.path)
+		require.NoError(t, err)
+
+		fields := strings.Fields(stdout.String())
+		require.GreaterOrEqual(t, len(fields), 4, "unexpected ls output for %s: %q", tc.path, stdout.String())
+		assert.Equal(t, tc.perms, fields[0], "perms for %s", tc.path)
+		assert.Equal(t, tc.uid, fields[2], "uid for %s", tc.path)
+		assert.Equal(t, tc.gid, fields[3], "gid for %s", tc.path)
+	}
+}
+
 func TestE2EDownImages(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)

--- a/cmd/incus-compose/e2e_test.go
+++ b/cmd/incus-compose/e2e_test.go
@@ -789,6 +789,33 @@ func TestE2EUpDownWithSecrets(t *testing.T) {
 	runE2ETests(t, ctx, pn, tests)
 }
 
+func TestE2EUpDownWithConfigs(t *testing.T) {
+	t.Parallel()
+	skipLocal(t)
+	skipE2E(t)
+
+	ctx := context.Background()
+	pn := t.Name()
+	compose := "../../test/fixtures/with-configs/compose.yaml"
+
+	t.Cleanup(func() {
+		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+	})
+
+	tests := []e2eTest{
+		{
+			name: "up with-configs",
+			args: []string{"-f", compose, "up", "--detach"},
+		},
+		{
+			name: "list with-configs",
+			args: []string{"-f", compose, "list"},
+		},
+	}
+
+	runE2ETests(t, ctx, pn, tests)
+}
+
 func TestE2EDownImages(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)

--- a/cmd/incus-compose/e2e_test.go
+++ b/cmd/incus-compose/e2e_test.go
@@ -789,6 +789,47 @@ func TestE2EUpDownWithSecrets(t *testing.T) {
 	runE2ETests(t, ctx, pn, tests)
 }
 
+func TestE2EUpDownWithSecretsVerifyFiles(t *testing.T) {
+	t.Parallel()
+	skipLocal(t)
+	skipE2E(t)
+
+	ctx := context.Background()
+	pn := t.Name()
+	compose := "../../test/fixtures/with-secrets/compose.yaml"
+
+	t.Cleanup(func() {
+		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+	})
+
+	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	require.NoError(t, err)
+
+	// Verify each secret file exists with correct perms/ownership
+	checks := []struct {
+		path  string
+		perms string
+		uid   string
+		gid   string
+	}{
+		{"/run/secrets/demo_secret", "-r--------", "0", "0"},   // default mode 0o600
+		{"/run/secrets/db_password", "-r--------", "0", "0"},   // default mode 0o600
+		{"/app/secrets/api.key", "-r--r--r--", "1000", "1000"}, // explicit 0o444 + uid/gid
+	}
+
+	for _, tc := range checks {
+		stdout, err := runCommand(t, ctx, pn, "-f", compose, "exec", "--no-tty", "app",
+			"--", "ls", "-ln", tc.path)
+		require.NoError(t, err)
+
+		fields := strings.Fields(stdout.String())
+		require.GreaterOrEqual(t, len(fields), 4, "unexpected ls output for %s: %q", tc.path, stdout.String())
+		assert.Equal(t, tc.perms, fields[0], "perms for %s", tc.path)
+		assert.Equal(t, tc.uid, fields[2], "uid for %s", tc.path)
+		assert.Equal(t, tc.gid, fields[3], "gid for %s", tc.path)
+	}
+}
+
 func TestE2EUpDownWithConfigs(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
@@ -839,9 +880,9 @@ func TestE2EUpDownWithConfigsVerifyFiles(t *testing.T) {
 		uid   string
 		gid   string
 	}{
-		{"/app_config", "-rw-r--r--", "0", "0"},                  // default mode 0644
-		{"/db_config", "-rw-r--r--", "0", "0"},                  // default mode 0644
-		{"/etc/nginx/nginx.conf", "-rw-r-----", "101", "101"},   // explicit 0640 + uid/gid
+		{"/app_config", "-r--r--r--", "0", "0"},               // default mode 0o444
+		{"/db_config", "-r--r--r--", "0", "0"},                // default mode 0o444
+		{"/etc/nginx/nginx.conf", "-r--r-----", "101", "101"}, // explicit 0o640, write bit ignored -> 0o440
 	}
 
 	for _, tc := range checks {

--- a/cmd/incus-compose/main_test.go
+++ b/cmd/incus-compose/main_test.go
@@ -174,6 +174,11 @@ func TestConfigCommand(t *testing.T) {
 			fixture: "../../test/fixtures/with-secrets",
 		},
 		{
+			name:    "with-configs",
+			args:    []string{"-f", "../../test/fixtures/with-configs/compose.yaml", "config"},
+			fixture: "../../test/fixtures/with-configs",
+		},
+		{
 			name:    "with-restart",
 			args:    []string{"-f", "../../test/fixtures/with-restart/compose.yaml", "config"},
 			fixture: "../../test/fixtures/with-restart",

--- a/project/instance.go
+++ b/project/instance.go
@@ -982,10 +982,10 @@ func instanceConfigs(p *types.Project, service types.ServiceConfig) ([]client.In
 	return result, errs
 }
 
-// parseConfigMode parses a file mode to int, defaulting to 0444.
+// parseConfigMode parses a file mode to int, defaulting to 0644.
 func parseConfigMode(mode *types.FileMode) int {
 	if mode == nil {
-		return 0o444
+		return 0o644
 	}
 	return int(*mode)
 }

--- a/project/instance.go
+++ b/project/instance.go
@@ -112,6 +112,12 @@ func serviceToInstance(c *client.Client, p *types.Project, serviceName string, o
 	}
 	files = append(files, secrets...)
 
+	configs, err := instanceConfigs(p, service)
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+	files = append(files, configs...)
+
 	if errs != nil {
 		return nil, nil, errs
 	}
@@ -922,6 +928,66 @@ func formatTmpfsSize(opts *types.ServiceVolumeTmpfs) string {
 		return ""
 	}
 	return strconv.FormatInt(int64(opts.Size), 10)
+}
+
+// instanceConfigs resolves a service's configs from their compose definitions,
+// reading content from a file, inline content, or an environment variable.
+func instanceConfigs(p *types.Project, service types.ServiceConfig) ([]client.InstanceFile, error) {
+	var errs error
+	result := []client.InstanceFile{}
+
+	for _, svcConfig := range service.Configs {
+		configDef, ok := p.Configs[svcConfig.Source]
+		if !ok {
+			errs = errors.Join(errs, fmt.Errorf("config %q not defined", svcConfig.Source))
+			continue
+		}
+
+		target := svcConfig.Target
+		if target == "" {
+			target = "/" + svcConfig.Source
+		}
+
+		switch {
+		case configDef.File != "":
+			fp, err := os.Open(configDef.File)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("config '%v' source not found or not readable", configDef.File))
+				continue
+			}
+			result = append(result, client.InstanceFile{
+				Target:  target,
+				Content: fp,
+				UID:     parseSecretID(svcConfig.UID),
+				GID:     parseSecretID(svcConfig.GID),
+				Mode:    parseConfigMode(svcConfig.Mode),
+			})
+		case configDef.Content != "":
+			result = append(result, client.InstanceFile{
+				Target:  target,
+				Content: client.NewReaderFromBytes([]byte(configDef.Content)),
+				UID:     parseSecretID(svcConfig.UID),
+				GID:     parseSecretID(svcConfig.GID),
+				Mode:    parseConfigMode(svcConfig.Mode),
+			})
+		case configDef.Environment != "":
+			errs = errors.Join(errs, fmt.Errorf("config '%v' environment variable '%v' not found", svcConfig.Source, configDef.Environment))
+			continue
+		default:
+			errs = errors.Join(errs, fmt.Errorf("config '%v' has no source (file, content, or environment)", svcConfig.Source))
+			continue
+		}
+	}
+
+	return result, errs
+}
+
+// parseConfigMode parses a file mode to int, defaulting to 0444.
+func parseConfigMode(mode *types.FileMode) int {
+	if mode == nil {
+		return 0o444
+	}
+	return int(*mode)
 }
 
 // parseSecretID parses a UID string to int64.

--- a/project/instance.go
+++ b/project/instance.go
@@ -982,12 +982,13 @@ func instanceConfigs(p *types.Project, service types.ServiceConfig) ([]client.In
 	return result, errs
 }
 
-// parseConfigMode parses a file mode to int, defaulting to 0644.
+// parseConfigMode parses a file mode to int, defaulting to 0444. Per the
+// compose-spec, the writable bit must be ignored for configs.
 func parseConfigMode(mode *types.FileMode) int {
 	if mode == nil {
-		return 0o644
+		return 0o444
 	}
-	return int(*mode)
+	return int(*mode) &^ 0o222
 }
 
 // parseSecretID parses a UID string to int64.
@@ -999,12 +1000,13 @@ func parseSecretID(id string) int64 {
 	return v
 }
 
-// parseSecretMode parses a file mode to int.
+// parseSecretMode parses a file mode to int. Per the
+// compose-spec, the writable bit must be ignored for secrets.
 func parseSecretMode(mode *types.FileMode) int {
 	if mode == nil {
-		return 0o600
+		return 0o400
 	}
-	return int(*mode)
+	return int(*mode) &^ 0o222
 }
 
 // xICInstanceNetwork extracts the x-incus-compose.network string override

--- a/project/instance_test.go
+++ b/project/instance_test.go
@@ -336,6 +336,87 @@ func TestInstanceSecrets(t *testing.T) {
 	})
 }
 
+func TestInstanceConfigs(t *testing.T) {
+	t.Run("file source", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "config.txt")
+		require.NoError(t, os.WriteFile(path, []byte("config-value"), 0o644))
+		p := &types.Project{Configs: types.Configs{"app": {File: path}}}
+		service := types.ServiceConfig{Name: "web", Configs: []types.ServiceConfigObjConfig{{Source: "app", Target: "/etc/app.conf"}}}
+
+		configs, err := instanceConfigs(p, service)
+		require.NoError(t, err)
+		require.Len(t, configs, 1)
+		require.Equal(t, "/etc/app.conf", configs[0].Target)
+		assert.Equal(t, int64(-1), configs[0].UID)
+		assert.Equal(t, int64(-1), configs[0].GID)
+	})
+
+	t.Run("content source", func(t *testing.T) {
+		t.Parallel()
+		p := &types.Project{Configs: types.Configs{"app": {Content: "inline-config"}}}
+		service := types.ServiceConfig{Name: "web", Configs: []types.ServiceConfigObjConfig{{Source: "app", Target: "/etc/app.conf"}}}
+
+		configs, err := instanceConfigs(p, service)
+		require.NoError(t, err)
+		require.Len(t, configs, 1)
+		require.Equal(t, "/etc/app.conf", configs[0].Target)
+	})
+
+	t.Run("environment source", func(t *testing.T) {
+		p := &types.Project{Configs: types.Configs{"app": {Environment: "MY_CONFIG", Content: "env-value"}}}
+		service := types.ServiceConfig{Name: "web", Configs: []types.ServiceConfigObjConfig{{Source: "app", Target: "/etc/app.conf"}}}
+
+		configs, err := instanceConfigs(p, service)
+		require.NoError(t, err)
+		require.Len(t, configs, 1)
+		require.Equal(t, "/etc/app.conf", configs[0].Target)
+	})
+
+	t.Run("environment not found", func(t *testing.T) {
+		p := &types.Project{Configs: types.Configs{"app": {Environment: "MISSING"}}}
+		service := types.ServiceConfig{Name: "web", Configs: []types.ServiceConfigObjConfig{{Source: "app"}}}
+		_, err := instanceConfigs(p, service)
+		require.Error(t, err)
+	})
+
+	t.Run("undefined config", func(t *testing.T) {
+		t.Parallel()
+		service := types.ServiceConfig{Name: "web", Configs: []types.ServiceConfigObjConfig{{Source: "missing"}}}
+		_, err := instanceConfigs(&types.Project{}, service)
+		require.Error(t, err)
+	})
+
+	t.Run("no source", func(t *testing.T) {
+		t.Parallel()
+		p := &types.Project{Configs: types.Configs{"app": {}}}
+		service := types.ServiceConfig{Name: "web", Configs: []types.ServiceConfigObjConfig{{Source: "app"}}}
+		_, err := instanceConfigs(p, service)
+		require.Error(t, err)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+		p := &types.Project{Configs: types.Configs{"app": {File: filepath.Join(t.TempDir(), "nope")}}}
+		service := types.ServiceConfig{Name: "web", Configs: []types.ServiceConfigObjConfig{{Source: "app"}}}
+		_, err := instanceConfigs(p, service)
+		require.Error(t, err)
+	})
+
+	t.Run("default target", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "config.txt")
+		require.NoError(t, os.WriteFile(path, []byte("val"), 0o644))
+		p := &types.Project{Configs: types.Configs{"app": {File: path}}}
+		service := types.ServiceConfig{Name: "web", Configs: []types.ServiceConfigObjConfig{{Source: "app"}}}
+
+		configs, err := instanceConfigs(p, service)
+		require.NoError(t, err)
+		require.Len(t, configs, 1)
+		assert.Equal(t, "/app", configs[0].Target)
+	})
+}
+
 func TestServiceToInstanceUser(t *testing.T) {
 	t.Parallel()
 

--- a/project/instance_test.go
+++ b/project/instance_test.go
@@ -82,8 +82,8 @@ func TestParseSecretOwnershipAndMode(t *testing.T) {
 	assert.Equal(t, int64(-1), parseSecretID(""))
 	assert.Equal(t, int64(1000), parseSecretID("1000"))
 	assert.Equal(t, int64(0), parseSecretID("not-a-number"))
-	assert.Equal(t, 0o600, parseSecretMode(nil))
-	assert.Equal(t, 0o640, parseSecretMode(&mode))
+	assert.Equal(t, 0o400, parseSecretMode(nil))
+	assert.Equal(t, 0o440, parseSecretMode(&mode))
 }
 
 func TestFormatCommand(t *testing.T) {

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -520,6 +520,48 @@ func TestLoadWithSecrets(t *testing.T) {
 	assert.NotNil(t, app.Secrets[2].Mode)
 }
 
+// TestLoadWithConfigs tests loading a compose file with configs.
+func TestLoadWithConfigs(t *testing.T) {
+	t.Parallel()
+
+	proj, err := project.New().Load(
+		context.Background(), project.LoadWorkingDir(fixturePath("with-configs")),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, proj)
+	assert.Equal(t, "with-configs", proj.Name)
+
+	// Check configs are defined.
+	assert.Len(t, proj.Configs, 3)
+	assert.Contains(t, proj.Configs, "app_config")
+	assert.Contains(t, proj.Configs, "db_config")
+	assert.Contains(t, proj.Configs, "nginx_config")
+
+	// Check app_config config (file-based).
+	appConfig := proj.Configs["app_config"]
+	assert.NotEmpty(t, appConfig.File)
+
+	// Check db_config config (content-based).
+	dbConfig := proj.Configs["db_config"]
+	assert.NotEmpty(t, dbConfig.Content)
+
+	// Check service has configs configured.
+	app, exists := proj.Services["app"]
+	assert.True(t, exists, "app service should exist")
+	assert.Len(t, app.Configs, 3)
+
+	// Check first config (simple reference).
+	assert.Equal(t, "app_config", app.Configs[0].Source)
+
+	// Check third config (with custom target).
+	assert.Equal(t, "nginx_config", app.Configs[2].Source)
+	assert.Equal(t, "/etc/nginx/nginx.conf", app.Configs[2].Target)
+	assert.Equal(t, "101", app.Configs[2].UID)
+	assert.Equal(t, "101", app.Configs[2].GID)
+	assert.NotNil(t, app.Configs[2].Mode)
+}
+
 // TestLoadWithRestartPolicies tests loading a compose file with restart policies.
 func TestLoadWithRestartPolicies(t *testing.T) {
 	t.Parallel()

--- a/test/fixtures/with-configs/.env
+++ b/test/fixtures/with-configs/.env
@@ -1,0 +1,1 @@
+NGINX_CONFIG=server { listen 80; }

--- a/test/fixtures/with-configs/app_config.txt
+++ b/test/fixtures/with-configs/app_config.txt
@@ -1,0 +1,2 @@
+APP_NAME=myapp
+APP_ENV=production

--- a/test/fixtures/with-configs/compose.yaml
+++ b/test/fixtures/with-configs/compose.yaml
@@ -8,7 +8,7 @@ services:
         target: /etc/nginx/nginx.conf
         uid: "101"
         gid: "101"
-        mode: 0644
+        mode: 0o640
 
 configs:
   app_config:

--- a/test/fixtures/with-configs/compose.yaml
+++ b/test/fixtures/with-configs/compose.yaml
@@ -1,0 +1,21 @@
+services:
+  app:
+    image: docker.io/library/busybox:glibc
+    configs:
+      - app_config
+      - db_config
+      - source: nginx_config
+        target: /etc/nginx/nginx.conf
+        uid: "101"
+        gid: "101"
+        mode: 0440
+
+configs:
+  app_config:
+    file: ./app_config.txt
+  db_config:
+    content: |
+      DB_HOST=localhost
+      DB_PORT=5432
+  nginx_config:
+    environment: NGINX_CONFIG

--- a/test/fixtures/with-configs/compose.yaml
+++ b/test/fixtures/with-configs/compose.yaml
@@ -8,7 +8,7 @@ services:
         target: /etc/nginx/nginx.conf
         uid: "101"
         gid: "101"
-        mode: 0440
+        mode: 0644
 
 configs:
   app_config:

--- a/test/fixtures/with-secrets/compose.yaml
+++ b/test/fixtures/with-secrets/compose.yaml
@@ -8,7 +8,7 @@ services:
         target: /app/secrets/api.key
         uid: "1000"
         gid: "1000"
-        mode: 0644
+        mode: 0o444
 
 secrets:
   db_password:

--- a/test/fixtures/with-secrets/compose.yaml
+++ b/test/fixtures/with-secrets/compose.yaml
@@ -8,7 +8,7 @@ services:
         target: /app/secrets/api.key
         uid: "1000"
         gid: "1000"
-        mode: 0440
+        mode: 0644
 
 secrets:
   db_password:

--- a/test/snapshots/e2e/TestConfigCommand-with-configs
+++ b/test/snapshots/e2e/TestConfigCommand-with-configs
@@ -1,0 +1,30 @@
+project:
+  name: test-local-config
+  services:
+    app:
+      configs:
+        - source: app_config
+        - source: db_config
+        - source: nginx_config
+          target: /etc/nginx/nginx.conf
+          uid: "101"
+          gid: "101"
+          mode: "0440"
+      image: docker.io/library/busybox:glibc
+      networks:
+        default: null
+  networks:
+    default:
+      name: test-local-config_default
+  configs:
+    app_config:
+      name: test-local-config_app_config
+      file: $FIXTURE_PATH/app_config.txt
+    db_config:
+      name: test-local-config_db_config
+      content: |
+        DB_HOST=localhost
+        DB_PORT=5432
+    nginx_config:
+      name: test-local-config_nginx_config
+      environment: NGINX_CONFIG

--- a/test/snapshots/e2e/TestConfigCommand-with-configs
+++ b/test/snapshots/e2e/TestConfigCommand-with-configs
@@ -9,7 +9,7 @@ project:
           target: /etc/nginx/nginx.conf
           uid: "101"
           gid: "101"
-          mode: "0644"
+          mode: "0640"
       image: docker.io/library/busybox:glibc
       networks:
         default: null

--- a/test/snapshots/e2e/TestConfigCommand-with-configs
+++ b/test/snapshots/e2e/TestConfigCommand-with-configs
@@ -9,7 +9,7 @@ project:
           target: /etc/nginx/nginx.conf
           uid: "101"
           gid: "101"
-          mode: "0440"
+          mode: "0644"
       image: docker.io/library/busybox:glibc
       networks:
         default: null

--- a/test/snapshots/e2e/TestConfigCommand-with-secrets
+++ b/test/snapshots/e2e/TestConfigCommand-with-secrets
@@ -14,7 +14,7 @@ project:
           target: /app/secrets/api.key
           uid: "1000"
           gid: "1000"
-          mode: "0440"
+          mode: "0644"
   networks:
     default:
       name: test-local-config_default

--- a/test/snapshots/e2e/TestConfigCommand-with-secrets
+++ b/test/snapshots/e2e/TestConfigCommand-with-secrets
@@ -14,7 +14,7 @@ project:
           target: /app/secrets/api.key
           uid: "1000"
           gid: "1000"
-          mode: "0644"
+          mode: "0444"
   networks:
     default:
       name: test-local-config_default


### PR DESCRIPTION
Implements compose-spec configs support (the non-sensitive counterpart to secrets). Services can now reference configs defined at the top level, which are pushed into containers as files before startup — identical mechanism to secrets/bind-mount seeding.

closes #62 