### PR TITLE
feat(client): add well-known OCI registries transparently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ for correct semver ordering. Headings below preserve each release's announced fo
   Linux VM), linking to the new Windows getting-started guide.
 - `incus-compose-bin` and `incus-compose-git` AUR packages are now referenced
   in the README as install options.
+- Well-known OCI registries (`docker.io`, `ghcr.io`, `mcr.microsoft.com`,
+  `quay.io`, `registry.gitlab.com`) are now auto-added to the in-memory Incus CLI config
+  when an image from that registry is used, removing the need for manual
+  `incus remote add` steps.
 
 ### Fixed
 

--- a/client/global_client.go
+++ b/client/global_client.go
@@ -160,6 +160,8 @@ func New(ctx context.Context, opts ...ClientOption) *GlobalClient {
 		return ErrUnknown.WithResource(r).Wrap(err)
 	}
 
+	AddWellKnownRegistriesHook(c)
+
 	c.hookOperation = func(ctx context.Context, action Action, r Resource, args Options, op incusClient.Operation, err error) error {
 		if err != nil {
 			return err

--- a/client/wellknown.go
+++ b/client/wellknown.go
@@ -14,15 +14,17 @@ import (
 var WellKnownRegistries = map[string]string{
 	"ghcr.io":             "https://ghcr.io",
 	"docker.io":           "https://docker.io",
+	"mcr.microsoft.com":   "https://mcr.microsoft.com",
+	"quay.io":             "https://quay.io",
 	"registry.gitlab.com": "https://registry.gitlab.com",
 }
-
-var wellKnownMu = &sync.Mutex{}
 
 // AddWellKnownRegistriesHook registers a hook that transparently adds
 // well-known OCI registries to the in-memory CLI config when an image from
 // that registry is about to be ensured.
 func AddWellKnownRegistriesHook(c *GlobalClient) {
+	wellKnownMu := &sync.Mutex{}
+
 	c.AddHookBefore(func(_ context.Context, action Action, r Resource, _ Options, err error) error {
 		if action != ActionEnsure || r.Kind() != KindImage {
 			return err

--- a/client/wellknown.go
+++ b/client/wellknown.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"context"
+	"sync"
+
+	"github.com/lxc/incus/v7/shared/cliconfig"
+)
+
+// WellKnownRegistries maps well-known OCI registry domains to their server URLs.
+// Registries in this map are added to the in-memory Incus CLI config on demand
+// when an image from that registry is ensured, removing the need for manual
+// `incus remote add` steps.
+var WellKnownRegistries = map[string]string{
+	"ghcr.io":             "https://ghcr.io",
+	"docker.io":           "https://docker.io",
+	"registry.gitlab.com": "https://registry.gitlab.com",
+}
+
+var wellKnownMu = &sync.Mutex{}
+
+// AddWellKnownRegistriesHook registers a hook that transparently adds
+// well-known OCI registries to the in-memory CLI config when an image from
+// that registry is about to be ensured.
+func AddWellKnownRegistriesHook(c *GlobalClient) {
+	c.AddHookBefore(func(_ context.Context, action Action, r Resource, _ Options, err error) error {
+		if action != ActionEnsure || r.Kind() != KindImage {
+			return err
+		}
+
+		img, ok := r.(*Image)
+		if !ok {
+			return err
+		}
+
+		remote := img.Remote()
+		url, ok := WellKnownRegistries[remote]
+		if !ok {
+			return err
+		}
+
+		wellKnownMu.Lock()
+		if _, exists := c.CliConfig().Remotes[remote]; !exists {
+			c.CliConfig().Remotes[remote] = cliconfig.Remote{
+				Addrs:    []string{url},
+				Protocol: "oci",
+				Public:   true,
+			}
+		}
+		wellKnownMu.Unlock()
+
+		return err
+	})
+}

--- a/client/wellknown_test.go
+++ b/client/wellknown_test.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lxc/incus/v7/shared/cliconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddWellKnownRegistriesHook(t *testing.T) {
+	gc := New(context.Background())
+
+	delete(gc.CliConfig().Remotes, "ghcr.io")
+
+	img := &Image{
+		BaseResource: NewBaseResource(KindImage, "ghcr.io/lxc/incus-compose/ic-healthd:latest", PriorityImage),
+		incusName:    "ghcr.io/lxc/incus-compose/ic-healthd:latest",
+		remote:       "ghcr.io",
+		image:        "lxc/incus-compose/ic-healthd:latest",
+	}
+
+	err := gc.hookBefore(context.Background(), ActionEnsure, img, Options{}, nil)
+	require.NoError(t, err)
+
+	remote, ok := gc.CliConfig().Remotes["ghcr.io"]
+	require.True(t, ok, "ghcr.io should be added by hook")
+
+	require.Equal(t, "oci", remote.Protocol)
+	require.True(t, remote.Public)
+	require.Equal(t, []string{"https://ghcr.io"}, remote.Addrs)
+}
+
+func TestWellKnownHookSkipsNonEnsure(t *testing.T) {
+	gc := New(context.Background())
+
+	delete(gc.CliConfig().Remotes, "ghcr.io")
+
+	img := &Image{
+		BaseResource: NewBaseResource(KindImage, "ghcr.io/something:latest", PriorityImage),
+		incusName:    "ghcr.io/something:latest",
+		remote:       "ghcr.io",
+		image:        "something:latest",
+	}
+
+	err := gc.hookBefore(context.Background(), ActionDelete, img, Options{}, nil)
+	require.NoError(t, err)
+
+	_, ok := gc.CliConfig().Remotes["ghcr.io"]
+	require.False(t, ok, "ghcr.io should not be added for non-Ensure actions")
+}
+
+func TestWellKnownHookSkipsUnknownRegistries(t *testing.T) {
+	gc := New(context.Background())
+
+	img := &Image{
+		BaseResource: NewBaseResource(KindImage, "unknown.registry.example.com/image:tag", PriorityImage),
+		incusName:    "unknown.registry.example.com/image:tag",
+		remote:       "unknown.registry.example.com",
+		image:        "image:tag",
+	}
+
+	err := gc.hookBefore(context.Background(), ActionEnsure, img, Options{}, nil)
+	require.NoError(t, err)
+
+	_, ok := gc.CliConfig().Remotes["unknown.registry.example.com"]
+	require.False(t, ok, "unknown registry should not be added")
+}
+
+func TestWellKnownHookSkipsExistingRemotes(t *testing.T) {
+	gc := New(context.Background())
+
+	gc.CliConfig().Remotes["ghcr.io"] = cliconfig.Remote{
+		Addrs:    []string{"https://custom.example.com"},
+		Protocol: "oci",
+		Public:   true,
+	}
+
+	img := &Image{
+		BaseResource: NewBaseResource(KindImage, "ghcr.io/something:latest", PriorityImage),
+		incusName:    "ghcr.io/something:latest",
+		remote:       "ghcr.io",
+		image:        "something:latest",
+	}
+
+	err := gc.hookBefore(context.Background(), ActionEnsure, img, Options{}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "https://custom.example.com", gc.CliConfig().Remotes["ghcr.io"].Addrs[0],
+		"existing remote should not be overwritten")
+}

--- a/cmd/incus-compose/wellknown_test.go
+++ b/cmd/incus-compose/wellknown_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWellKnownRegistryQuayIO(t *testing.T) {
+	t.Parallel()
+	skipLocal(t)
+
+	ctx := context.Background()
+	pn := t.Name()
+
+	dir := writeTempFiles(t, map[string]string{
+		"compose.yaml": `services:
+  hello:
+    image: quay.io/podman/hello
+`,
+	})
+	compose := filepath.Join(dir, "compose.yaml")
+
+	t.Cleanup(func() {
+		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+	})
+
+	_, err := runCommand(t, ctx, pn, "-f", compose, "pull", "--no-healthd", "hello")
+	require.NoError(t, err)
+}
+
+func TestWellKnownRegistryMCR(t *testing.T) {
+	t.Parallel()
+	skipLocal(t)
+
+	ctx := context.Background()
+	pn := t.Name()
+
+	dir := writeTempFiles(t, map[string]string{
+		"compose.yaml": `services:
+  hello:
+    image: mcr.microsoft.com/azurelinux/busybox:1.36
+`,
+	})
+	compose := filepath.Join(dir, "compose.yaml")
+
+	t.Cleanup(func() {
+		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+	})
+
+	_, err := runCommand(t, ctx, pn, "-f", compose, "pull", "--no-healthd", "hello")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Registries like docker.io, ghcr.io and registry.gitlab.com are now automatically added to the in-memory CLI config when an image from that registry is about to be ensured. This removes the need for manual `incus remote add` steps.

closes #14 