### PR TITLE
fix: stricter golangci-lint config and clear findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,76 +1,152 @@
 version: "2"
+run:
+  modules-download-mode: readonly
+  issues-exit-code: 1
+  tests: true
+output:
+  formats:
+    text:
+      path: stdout
+      print-linter-name: true
+      print-issued-lines: true
 linters:
   enable:
-    - godot
+    - bodyclose
+    - dogsled
+    - dupl
+    - errorlint
+    - exhaustive
+    - gochecknoinits
+    - gocritic
+    - gosec
     - misspell
+    - nakedret
+    - nilerr
+    - noctx
+    - predeclared
     - revive
+    - unconvert
+    - unparam
     - whitespace
-    - sloglint
+  disable:
+    - goconst
+    - depguard
+    - funlen
+    - gocognit
+    - gocyclo
+    - lll
+    - prealloc
   settings:
+    dupl:
+      threshold: 150
     errcheck:
+      check-type-assertions: true
+      check-blank: false
       exclude-functions:
+        - io.Copy
+        - io.ReadAll
         - (io.ReadCloser).Close
-        - (io.WriteCloser).Close
-        - (io.ReadWriteCloser).Close
-        - (*os.File).Close
-        - os.Remove
+        - (*encoding/json.Encoder).Encode
+        - (*github.com/docker/docker/client.Client).Close
+        - (*io.SectionReader).Seek
+    errorlint:
+      errorf: true
+      asserts: true
+      comparison: true
+    exhaustive:
+      default-signifies-exhaustive: true
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - hugeParam
+        - rangeValCopy
+        - ifElseChain
+        - elseif
+        - appendCombine
+        - commentedOutCode
+      enabled-tags:
+        - diagnostic
+        - performance
+    gosec:
+      excludes:
+        - G104
+        - G115
+        - G304
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    misspell:
+      locale: US
+    nakedret:
+      max-func-lines: 30
+    prealloc:
+      simple: true
+      for-loops: true
     revive:
       rules:
-        - name: exported
-          arguments:
-            - checkPrivateReceivers
-            - disableStutteringCheck
-        - name: import-shadowing
-        - name: unchecked-type-assertion
-        - name: var-naming
-          arguments:
-            - []
-            - []
-            - - upperCaseConst: true
-        - name: early-return
-        - name: redundant-import-alias
-        - name: redefines-builtin-id
-        - name: struct-tag
-        - name: receiver-naming
-        - name: deep-exit
-        - name: defer
-        - name: bool-literal-in-expr
-        - name: comment-spacings
-        - name: use-any
-        - name: bare-return
-        - name: empty-block
-        - name: range-val-address
-        - name: range-val-in-closure
-        - name: var-declaration
-        - name: useless-break
-        - name: error-naming
-        - name: indent-error-flow
-        - name: datarace
-        - name: modifies-value-receiver
-        - name: empty-lines
-        - name: duplicated-imports
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
         - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+          disabled: true
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+          disabled: true
+        - name: var-declaration
+        - name: var-naming
+    unparam:
+      check-exported: false
   exclusions:
     generated: lax
     rules:
       - linters:
-          - staticcheck
-        text: "ST1005:"
+          - dupl
+          - errcheck
+          - goconst
+          - gosec
+          - govet
+          - unparam
+        path: _test\.go
       - linters:
-          - godot
-        text: "Comment should end in a period"
-        source: "^// Example:"
+          - forbidigo
+        path: cmd/
+      - linters:
+          - dupl
+          - goconst
+          - gocritic
+        path: .*\.gen\.go$
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+severity:
+  default: warning
+  rules:
+    - linters:
+        - errcheck
+        - gosec
+      severity: error
 formatters:
   enable:
-    - gci
-    - gofumpt
+    - gofmt
     - goimports
   settings:
-    gci:
-      sections:
-        - standard
-        - default
-        - prefix(github.com/lxc/incus-compose)
     goimports:
       local-prefixes:
         - github.com/lxc/incus-compose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ for correct semver ordering. Headings below preserve each release's announced fo
   release-artifact naming (`checksums.txt`), it was still using the old
   `${PROJECT_NAME}_${VERSION}_checksums.txt` pattern.
 
+### Internal
+
+- `.golangci.yml`: enabled a much stricter linter set, and fixed the
+  resulting findings across the codebase.
+
 ## [1.0.0] - 2026-07-10
 
 The first stable release! _hooray_

--- a/client/build.go
+++ b/client/build.go
@@ -14,7 +14,7 @@ const (
 
 // BuildInfo carries the rebuild mode and optional builder selection for ActionEnsure.
 type BuildInfo struct {
-	// Mode controls rebuild behaviour.
+	// Mode controls rebuild behavior.
 	Mode BuildMode
 
 	// PreferredBuilder is the container builder binary name or absolute path.

--- a/client/build_linux.go
+++ b/client/build_linux.go
@@ -59,7 +59,10 @@ func buildRootfs(ctx context.Context, builder string, cfg *BuildConfig, stdout i
 		return nil, nil, fmt.Errorf("creating temp file: %w", err)
 	}
 	rootfsPath := rootfsTmp.Name()
-	rootfsTmp.Close()
+	err = rootfsTmp.Close()
+	if err != nil {
+		return nil, nil, err
+	}
 
 	buildCfg, cleanup, err := buildConfigWithInlineDockerfile(cfg)
 	if err != nil {
@@ -69,7 +72,7 @@ func buildRootfs(ctx context.Context, builder string, cfg *BuildConfig, stdout i
 	defer cleanup()
 
 	args := buildArgs(isPodman, buildCfg, tmpTag, rootfsPath)
-	cmd := exec.CommandContext(ctx, builder, args...)
+	cmd := exec.CommandContext(ctx, builder, args...) //nolint:gosec
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
@@ -88,7 +91,7 @@ func buildRootfs(ctx context.Context, builder string, cfg *BuildConfig, stdout i
 	}
 
 	// Remove the temporary image tag; ignore errors (best-effort cleanup).
-	rmi := exec.CommandContext(ctx, builder, "rmi", tmpTag)
+	rmi := exec.CommandContext(ctx, builder, "rmi", tmpTag) //nolint:gosec
 	rmi.Stdout = stdout
 	rmi.Stderr = stderr
 	_ = rmi.Run()
@@ -110,7 +113,7 @@ func buildConfigJSON(ctx context.Context, builder, tmpTag string, logW io.Writer
 	}
 	defer func() { _ = os.RemoveAll(ociDir) }()
 
-	save := exec.CommandContext(ctx, builder, "save", "--format", "oci-dir", "-o", ociDir, tmpTag)
+	save := exec.CommandContext(ctx, builder, "save", "--format", "oci-dir", "-o", ociDir, tmpTag) //nolint:gosec
 	save.Stderr = logW
 	if err := save.Run(); err != nil {
 		return nil, fmt.Errorf("saving OCI image: %w", err)

--- a/client/client_dnswatcher.go
+++ b/client/client_dnswatcher.go
@@ -147,6 +147,8 @@ func (c *Client) RegisterDNSWatcher() error {
 				delete(instanceIPs, inst.IncusName())
 
 				changed = true
+			default:
+				// ActionDelete and ActionLog don't affect DNS registration.
 			}
 
 			if !changed {
@@ -204,6 +206,9 @@ func (c *Client) RegisterDNSWatcher() error {
 			}
 
 			return nil
+
+		default:
+			// Other kinds are not relevant to DNS watching.
 		}
 
 		return nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -32,7 +32,7 @@ func skipLocal(t *testing.T) {
 
 // newRandomTestClient creates a GlobalClient, a fresh project-scoped Client,
 // and registers t.Cleanup to delete the project on teardown.
-func newRandomTestClient(t *testing.T, ctx context.Context, prefix string) *Client {
+func newRandomTestClient(ctx context.Context, t *testing.T, prefix string) *Client {
 	t.Helper()
 	gc, err := NewTestClient(ctx)
 	require.NoError(t, err)

--- a/client/global_client.go
+++ b/client/global_client.go
@@ -337,7 +337,7 @@ func (c *GlobalClient) Connect() error {
 	}
 
 	if c.config.DefaultStoragePool == "detect" {
-		if err = c.detectStoragePool(); err != nil {
+		if err := c.detectStoragePool(); err != nil {
 			return err
 		}
 	}
@@ -759,9 +759,14 @@ func (c *GlobalClient) ConnectionIPs() ([]net.IP, error) {
 		return c.connectionIPs, nil
 	}
 
-	ips, err := net.LookupIP(u.Hostname())
+	addrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), u.Hostname())
 	if err != nil {
 		return nil, fmt.Errorf("while looking up the IP for %q: %w", c.config.URL, err)
+	}
+
+	ips := make([]net.IP, len(addrs))
+	for i, addr := range addrs {
+		ips[i] = addr.IP
 	}
 
 	c.connectionIPs = ips

--- a/client/pool.go
+++ b/client/pool.go
@@ -71,7 +71,7 @@ func (p *WorkerPool) Run(args PoolRunArgs) error {
 		go func() {
 			defer wg.Done()
 			for task := range taskCh {
-				// Check if cancelled
+				// Check if canceled
 				select {
 				case <-cancelCh:
 					return

--- a/client/resource.go
+++ b/client/resource.go
@@ -51,7 +51,7 @@ type Options struct {
 	// Pull forces cached images to refresh from their source registry (for ActionEnsure).
 	Pull bool
 
-	// Build controls rebuild behaviour for build-configured images (for ActionEnsure).
+	// Build controls rebuild behavior for build-configured images (for ActionEnsure).
 	Build BuildInfo
 
 	// Healthd indicates that we use healthd features.

--- a/client/resource_image.go
+++ b/client/resource_image.go
@@ -587,8 +587,8 @@ func extractAndStoreOCIConfig(ctx context.Context, server incusClient.InstanceSe
 	if props == nil {
 		props = make(map[string]string)
 	}
-	props["oci.uid"] = strconv.FormatUint(uint64(uid), 10)
-	props["oci.gid"] = strconv.FormatUint(uint64(gid), 10)
+	props["oci.uid"] = strconv.FormatUint(uid, 10)
+	props["oci.gid"] = strconv.FormatUint(gid, 10)
 	props["oci.entrypoint"] = entrypoint
 	props["oci.cwd"] = cwd
 
@@ -697,7 +697,7 @@ func (r *Image) buildImage(ctx context.Context, args Options) error {
 	if err != nil {
 		return ErrCreate.WithText("building container image").Wrap(err)
 	}
-	defer rootfs.Close()
+	defer r.client.WarnError(rootfs.Close, "Failure during close")
 
 	meta, err := buildMetadataTar(r.incusName, incusArch, configJSON)
 	if err != nil {

--- a/client/resource_image_test.go
+++ b/client/resource_image_test.go
@@ -209,7 +209,7 @@ func TestImageEnsure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "image-ensure-")
+			c := newRandomTestClient(ctx, t, "image-ensure-")
 
 			r, err := c.Resource(KindImage, tt.image, &ImageConfig{})
 			require.NoError(t, err)
@@ -235,7 +235,7 @@ func TestImageEnsure_Idempotent(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "image-idempotent-")
+	c := newRandomTestClient(ctx, t, "image-idempotent-")
 
 	r, err := c.Resource(KindImage, "docker.io/library/busybox:latest", &ImageConfig{})
 	require.NoError(t, err)
@@ -251,7 +251,7 @@ func TestImageEnsure_WithoutCreate_ThenWithCreate(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "image-retry-")
+	c := newRandomTestClient(ctx, t, "image-retry-")
 
 	r, err := c.Resource(KindImage, "docker.io/library/busybox:latest", &ImageConfig{})
 	require.NoError(t, err)
@@ -269,7 +269,7 @@ func TestImageEnsure_ExistingImage_NewResource(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "image-existing-")
+	c := newRandomTestClient(ctx, t, "image-existing-")
 
 	r1, err := c.Resource(KindImage, "docker.io/library/busybox:latest", &ImageConfig{})
 	require.NoError(t, err)
@@ -291,7 +291,7 @@ func TestImageEnsure_ExistsOnNewClient(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "image-persist-")
+	c := newRandomTestClient(ctx, t, "image-persist-")
 
 	r, err := c.Resource(KindImage, "docker.io/library/busybox:latest", &ImageConfig{})
 	require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestImageDelete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "image-delete-")
+			c := newRandomTestClient(ctx, t, "image-delete-")
 
 			r, err := c.Resource(KindImage, "docker.io/library/busybox:latest", &ImageConfig{})
 			require.NoError(t, err)
@@ -356,7 +356,7 @@ func TestImageDelete_NotEnsured_NoError(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "image-delne-")
+	c := newRandomTestClient(ctx, t, "image-delne-")
 
 	r, err := c.Resource(KindImage, "docker.io/library/busybox:latest", &ImageConfig{})
 	require.NoError(t, err)
@@ -372,7 +372,7 @@ func TestImageProperties(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "image-props-")
+	c := newRandomTestClient(ctx, t, "image-props-")
 
 	r, err := c.Resource(KindImage, "ghcr.io/lxc/incus-compose/ic-healthd:latest", &ImageConfig{})
 	require.NoError(t, err)
@@ -391,7 +391,7 @@ func TestImageFromCache(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "image-from-cache-")
+	c := newRandomTestClient(ctx, t, "image-from-cache-")
 
 	r, err := c.Resource(KindImage, "docker.io/library/busybox:latest", &ImageConfig{})
 	require.NoError(t, err)
@@ -414,7 +414,7 @@ func TestImageNoCache(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "image-no-cache-")
+	c := newRandomTestClient(ctx, t, "image-no-cache-")
 	c.imageCache = nil
 
 	r, err := c.Resource(KindImage, "docker.io/library/busybox:latest", &ImageConfig{})
@@ -542,7 +542,7 @@ func TestImageHooks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "image-hook-")
+			c := newRandomTestClient(ctx, t, "image-hook-")
 			tt.run(t, c)
 		})
 	}

--- a/client/resource_instance.go
+++ b/client/resource_instance.go
@@ -434,7 +434,7 @@ func (r *Instance) create(ctx context.Context, opts ...Option) error {
 
 	// Create instance from project image.
 	op, err := r.conn.CreateInstanceFromImage(r.conn, *incusImage, req)
-	if err = r.client.hookRemoteOperation(ctx, ActionEnsure, r, options, op, err); err != nil {
+	if err := r.client.hookRemoteOperation(ctx, ActionEnsure, r, options, op, err); err != nil {
 		return err
 	}
 
@@ -443,7 +443,7 @@ func (r *Instance) create(ctx context.Context, opts ...Option) error {
 		return ErrCreate.WithText("fetching created instance").Wrap(err)
 	}
 
-	if err = r.ensured(); err != nil {
+	if err := r.ensured(); err != nil {
 		return err
 	}
 
@@ -474,7 +474,7 @@ func (r *Instance) buildDevices() (map[string]map[string]string, error) {
 		}
 
 		// The code below would have allowed us to overwrite `eth0`,
-		// but it breaks normal incus behaviour (instances overwrite profile).
+		// but it breaks normal incus behavior (instances overwrite profile).
 		// foundInProfile := false
 		// for _, profile := range profiles {
 		// 	foundInProfile = profile.HasDevice(name)
@@ -974,7 +974,7 @@ func sftpSetOwnerMode(sftpConn *sftp.Client, targetPath string, args incusClient
 	// Skip if not on UNIX.
 	_, err := sftpConn.StatVFS("/")
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // StatVFS failing means the remote isn't UNIX; nothing to set
 	}
 
 	// Get the current stat information.
@@ -985,7 +985,7 @@ func sftpSetOwnerMode(sftpConn *sftp.Client, targetPath string, args incusClient
 
 	fileStat, ok := st.Sys().(*sftp.FileStat)
 	if !ok {
-		return fmt.Errorf("Invalid filestat data for %q", targetPath)
+		return fmt.Errorf("invalid filestat data for %q", targetPath)
 	}
 
 	// Set owner.
@@ -1334,7 +1334,7 @@ func (r *Instance) logBuffer(outputHandler func(Action, Resource, []byte)) error
 	return nil
 }
 
-// logStream streams the console using WebSocket until context is cancelled.
+// logStream streams the console using WebSocket until context is canceled.
 func (r *Instance) logStream(ctx context.Context, options Options, outputHandler func(Action, Resource, []byte)) error {
 	// Channel to signal disconnect
 	consoleDisconnect := make(chan bool)
@@ -1379,7 +1379,7 @@ func (r *Instance) logStream(ctx context.Context, options Options, outputHandler
 
 	// Context cancellation (including timeout) is not an error
 	if ctx.Err() != nil {
-		return nil
+		return nil //nolint:nilerr // caller-initiated cancellation, not a streaming failure
 	}
 
 	if err != nil {

--- a/client/resource_instance_device.go
+++ b/client/resource_instance_device.go
@@ -179,7 +179,7 @@ func proxyEndpoint(addr string, port uint32) string {
 	return fmt.Sprintf("%s:%d", addr, port)
 }
 
-func (d *InstanceDevice) toProxyDevice() (map[string]string, error) {
+func (d *InstanceDevice) toProxyDevice() (map[string]string, error) { //nolint:unparam // signature matches the other toXDevice methods dispatched from ToIncusDevice
 	cfg := d.Config.Proxy
 
 	device := map[string]string{
@@ -197,7 +197,7 @@ func (d *InstanceDevice) toProxyDevice() (map[string]string, error) {
 	return device, nil
 }
 
-func (d *InstanceDevice) toDiskDevice() (map[string]string, error) {
+func (d *InstanceDevice) toDiskDevice() (map[string]string, error) { //nolint:unparam // signature matches the other toXDevice methods dispatched from ToIncusDevice
 	cfg := d.Config.Disk
 
 	device := map[string]string{
@@ -225,7 +225,7 @@ func (d *InstanceDevice) toDiskDevice() (map[string]string, error) {
 	return device, nil
 }
 
-func (d *InstanceDevice) toTmpfsDevice() (map[string]string, error) {
+func (d *InstanceDevice) toTmpfsDevice() (map[string]string, error) { //nolint:unparam // signature matches the other toXDevice methods dispatched from ToIncusDevice
 	cfg := d.Config.Tmpfs
 
 	device := map[string]string{

--- a/client/resource_network_test.go
+++ b/client/resource_network_test.go
@@ -369,7 +369,7 @@ func TestNetworkEnsure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "network-ensure-")
+			c := newRandomTestClient(ctx, t, "network-ensure-")
 
 			r, err := c.Resource(KindNetwork, tt.network, tt.config)
 			require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestNetworkEnsure_Idempotent(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "network-idempotent-")
+	c := newRandomTestClient(ctx, t, "network-idempotent-")
 
 	r, err := c.Resource(KindNetwork, "test-idempotent", &NetworkConfig{})
 	require.NoError(t, err)
@@ -409,7 +409,7 @@ func TestNetworkEnsure_WithoutCreate_ThenWithCreate(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "network-retry-")
+	c := newRandomTestClient(ctx, t, "network-retry-")
 
 	r, err := c.Resource(KindNetwork, "test-retry", &NetworkConfig{})
 	require.NoError(t, err)
@@ -427,7 +427,7 @@ func TestNetworkEnsure_ExistsOnNewClient(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "network-persist-")
+	c := newRandomTestClient(ctx, t, "network-persist-")
 
 	r, err := c.Resource(KindNetwork, "test-persist", &NetworkConfig{})
 	require.NoError(t, err)
@@ -447,7 +447,7 @@ func TestNetworkProjectDeletesNetwork(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "network-projdel-")
+	c := newRandomTestClient(ctx, t, "network-projdel-")
 
 	r, err := c.Resource(KindNetwork, "test-project-net", &NetworkConfig{})
 	require.NoError(t, err)
@@ -494,7 +494,7 @@ func TestNetworkDelete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "network-delete-")
+			c := newRandomTestClient(ctx, t, "network-delete-")
 
 			r, err := c.Resource(KindNetwork, "test-delete", &NetworkConfig{})
 			require.NoError(t, err)
@@ -634,7 +634,7 @@ func TestNetworkHooks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "network-hook-")
+			c := newRandomTestClient(ctx, t, "network-hook-")
 			tt.run(t, c)
 		})
 	}
@@ -648,7 +648,7 @@ func TestNetworkExternal_EnsureFailsIfNotExists(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "network-ext-")
+	c := newRandomTestClient(ctx, t, "network-ext-")
 
 	r, err := c.Resource(KindNetwork, "non-existent-external", &NetworkConfig{External: true})
 	require.NoError(t, err)
@@ -663,7 +663,7 @@ func TestNetworkExternal_DeleteIsNoOp(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "network-extdel-")
+	c := newRandomTestClient(ctx, t, "network-extdel-")
 
 	r, err := c.Resource(KindNetwork, "test-ext-del", &NetworkConfig{})
 	require.NoError(t, err)

--- a/client/resource_profile_test.go
+++ b/client/resource_profile_test.go
@@ -107,7 +107,7 @@ func TestProfileEnsure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "profile-ensure-")
+			c := newRandomTestClient(ctx, t, "profile-ensure-")
 
 			r, err := c.Resource(KindProfile, tt.profile, tt.config)
 			require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestProfileEnsure_Idempotent(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "profile-idempotent-")
+	c := newRandomTestClient(ctx, t, "profile-idempotent-")
 
 	r, err := c.Resource(KindProfile, "test-idempotent", &ProfileConfig{})
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestProfileEnsure_WithoutCreate_ThenWithCreate(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "profile-retry-")
+	c := newRandomTestClient(ctx, t, "profile-retry-")
 
 	r, err := c.Resource(KindProfile, "test-retry", &ProfileConfig{})
 	require.NoError(t, err)
@@ -165,7 +165,7 @@ func TestProfileEnsure_ExistsOnNewClient(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "profile-persist-")
+	c := newRandomTestClient(ctx, t, "profile-persist-")
 
 	r, err := c.Resource(KindProfile, "test-persist", &ProfileConfig{})
 	require.NoError(t, err)
@@ -206,7 +206,7 @@ func TestProfileDelete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "profile-delete-")
+			c := newRandomTestClient(ctx, t, "profile-delete-")
 
 			r, err := c.Resource(KindProfile, "test-delete", &ProfileConfig{})
 			require.NoError(t, err)
@@ -375,7 +375,7 @@ func TestProfileHooks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "profile-hook-")
+			c := newRandomTestClient(ctx, t, "profile-hook-")
 			tt.run(t, c)
 		})
 	}

--- a/client/resource_storage_volume.go
+++ b/client/resource_storage_volume.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"maps"
 	"os"
-	"path/filepath"
 	"strconv"
 
 	incusClient "github.com/lxc/incus/v7/client"
@@ -285,12 +284,13 @@ func (r *StorageVolume) pushDirectoryContent() error {
 		}
 	}
 
-	return filepath.WalkDir(r.Config.HostPath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
+	root, err := os.OpenRoot(r.Config.HostPath)
+	if err != nil {
+		return err
+	}
+	defer r.client.WarnError(root.Close, "Failure during close")
 
-		rel, err := filepath.Rel(r.Config.HostPath, path)
+	return fs.WalkDir(root.FS(), ".", func(rel string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -314,11 +314,11 @@ func (r *StorageVolume) pushDirectoryContent() error {
 			return r.conn.CreateStorageVolumeFile(r.Config.Pool, "custom", r.incusName, rel, args)
 		}
 
-		f, err := os.Open(path)
+		f, err := root.Open(rel)
 		if err != nil {
 			return err
 		}
-		defer f.Close()
+		defer r.client.WarnError(f.Close, "Failure during close")
 
 		args.Type = "file"
 		args.Content = f

--- a/client/resource_storage_volume_test.go
+++ b/client/resource_storage_volume_test.go
@@ -139,7 +139,7 @@ func TestStorageVolumeEnsure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "volume-ensure-")
+			c := newRandomTestClient(ctx, t, "volume-ensure-")
 
 			r, err := c.Resource(KindStorageVolume, tt.volume, tt.config)
 			require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestStorageVolumeEnsure_Idempotent(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "volume-idempotent-")
+	c := newRandomTestClient(ctx, t, "volume-idempotent-")
 
 	r, err := c.Resource(KindStorageVolume, "test-idempotent", &StorageVolumeConfig{})
 	require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestStorageVolumeEnsure_WithoutCreate_ThenWithCreate(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "volume-retry-")
+	c := newRandomTestClient(ctx, t, "volume-retry-")
 
 	r, err := c.Resource(KindStorageVolume, "test-retry", &StorageVolumeConfig{})
 	require.NoError(t, err)
@@ -197,7 +197,7 @@ func TestStorageVolumeEnsure_ShiftedVolume_Start(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "volume-shifted-")
+	c := newRandomTestClient(ctx, t, "volume-shifted-")
 
 	r, err := c.Resource(KindStorageVolume, "test-shifted", &StorageVolumeConfig{
 		Shifted: true,
@@ -214,7 +214,7 @@ func TestStorageVolumeEnsure_HealthdShiftedVolume(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "volume-healthd-")
+	c := newRandomTestClient(ctx, t, "volume-healthd-")
 
 	ir, err := c.Resource(KindImage, "ghcr.io/lxc/incus-compose/ic-healthd:latest", &ImageConfig{})
 	require.NoError(t, err)
@@ -240,7 +240,7 @@ func TestStorageVolumeEnsure_ExistsOnNewClient(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "volume-persist-")
+	c := newRandomTestClient(ctx, t, "volume-persist-")
 
 	r, err := c.Resource(KindStorageVolume, "test-persist", &StorageVolumeConfig{})
 	require.NoError(t, err)
@@ -281,7 +281,7 @@ func TestStorageVolumeDelete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "volume-delete-")
+			c := newRandomTestClient(ctx, t, "volume-delete-")
 
 			r, err := c.Resource(KindStorageVolume, "test-delete", &StorageVolumeConfig{})
 			require.NoError(t, err)
@@ -416,7 +416,7 @@ func TestStorageVolumeHooks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := newRandomTestClient(t, ctx, "volume-hook-")
+			c := newRandomTestClient(ctx, t, "volume-hook-")
 			tt.run(t, c)
 		})
 	}

--- a/client/stack.go
+++ b/client/stack.go
@@ -151,7 +151,7 @@ func (s *Stack) groupByPriority() [][]Resource {
 	return batches
 }
 
-func (s *Stack) runBatch(ctx context.Context, batch []Resource, kind Kind, action Action, opts ...Option) error {
+func (s *Stack) runBatch(ctx context.Context, batch []Resource, action Action, opts ...Option) error {
 	if len(batch) == 0 {
 		return nil
 	}
@@ -192,8 +192,7 @@ func (s *Stack) Run(ctx context.Context, action Action, stdout io.Writer, stderr
 	var errs error
 
 	for _, batch := range batches {
-		kind := batch[0].Kind()
-		err := s.runBatch(ctx, batch, kind, action, opts...)
+		err := s.runBatch(ctx, batch, action, opts...)
 		errs = errors.Join(errs, err)
 
 		if err != nil && s.options.FailFast {

--- a/client/stack_test.go
+++ b/client/stack_test.go
@@ -113,7 +113,7 @@ func TestParallelImageDownload(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "stack-parallel-")
+	c := newRandomTestClient(ctx, t, "stack-parallel-")
 
 	imageNames := []string{
 		"docker.io/library/busybox:1.36",
@@ -147,7 +147,7 @@ func TestStackHooksWithStack(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "stack-hooks-")
+	c := newRandomTestClient(ctx, t, "stack-hooks-")
 
 	var beforeCalled, afterCalled bool
 	var afterErr error
@@ -186,7 +186,7 @@ func TestStackErrorAggregation(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "stack-erragg-")
+	c := newRandomTestClient(ctx, t, "stack-erragg-")
 
 	stack := NewStack(c)
 
@@ -208,7 +208,7 @@ func TestStackInstanceWithSecrets(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "stack-secrets-")
+	c := newRandomTestClient(ctx, t, "stack-secrets-")
 
 	network, err := c.Resource(KindNetwork, "default", &NetworkConfig{})
 	require.NoError(t, err)
@@ -266,7 +266,7 @@ func TestStackEnsureWithoutCreate_Fails(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "stack-nocreate-")
+	c := newRandomTestClient(ctx, t, "stack-nocreate-")
 
 	profile, err := c.Resource(KindProfile, "p1", &ProfileConfig{})
 	require.NoError(t, err)
@@ -280,7 +280,7 @@ func TestStackSingleProfileEnsure(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "stack-profile-")
+	c := newRandomTestClient(ctx, t, "stack-profile-")
 
 	profile, err := c.Resource(KindProfile, "p1", &ProfileConfig{})
 	require.NoError(t, err)
@@ -299,7 +299,7 @@ func TestStackProfileAndNetworkMixedPriorities(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "stack-mixed-")
+	c := newRandomTestClient(ctx, t, "stack-mixed-")
 
 	profile, err := c.Resource(KindProfile, "p1", &ProfileConfig{})
 	require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestStackSimpleNginx(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "stack-nginx-")
+	c := newRandomTestClient(ctx, t, "stack-nginx-")
 
 	network, err := c.Resource(KindNetwork, "default", &NetworkConfig{})
 	require.NoError(t, err)
@@ -364,7 +364,7 @@ func TestStackNginxScale(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)
 	ctx := context.Background()
-	c := newRandomTestClient(t, ctx, "stack-scale-")
+	c := newRandomTestClient(ctx, t, "stack-scale-")
 
 	network, err := c.Resource(KindNetwork, "default", &NetworkConfig{})
 	require.NoError(t, err)

--- a/cmd/ic-healthd/checker.go
+++ b/cmd/ic-healthd/checker.go
@@ -43,7 +43,7 @@ const (
 	phaseRestart                    // restart the instance and re-enter the start period
 )
 
-// Run drives the health check loop until ctx is cancelled. It alternates
+// Run drives the health check loop until ctx is canceled. It alternates
 // between the start-period checker (start interval, bounded by the start
 // period) and the normal checker, restarting the instance with exponential
 // backoff when it stays unhealthy. inStart selects the start-period checker;
@@ -111,7 +111,7 @@ func (c *Checker) Run(ctx context.Context, inStart bool, startInstance bool) {
 // runPhase runs a single checking phase until a transition is required. When
 // inStart is true it uses the start interval and is bounded by the start
 // period; otherwise it uses the normal interval and runs until ctx is
-// cancelled. The returned phaseResult tells Run how to proceed.
+// canceled. The returned phaseResult tells Run how to proceed.
 func (c *Checker) runPhase(ctx context.Context, inStart bool) phaseResult {
 	interval := c.config.Interval
 	retries := c.config.Retries
@@ -287,7 +287,7 @@ func (c *Checker) exec(ctx context.Context, cmd []string) (int, string, string, 
 	case <-args.DataDone:
 	case <-ctx.Done():
 		if err := op.Cancel(); err != nil {
-			slog.Debug("cancelling exec operation", "instance", c.name, "error", err)
+			slog.Debug("canceling exec operation", "instance", c.name, "error", err)
 		}
 		return -1, "", "", ctx.Err()
 	}

--- a/cmd/ic-healthd/healthd_test.go
+++ b/cmd/ic-healthd/healthd_test.go
@@ -37,7 +37,7 @@ func skipE2E(t *testing.T) {
 	}
 }
 
-func runIncusCommand(t *testing.T, ctx context.Context, projectName string, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
+func runIncusCommand(ctx context.Context, t *testing.T, projectName string, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
 	t.Helper()
 
 	projectName = strings.ToLower(strings.ReplaceAll(projectName, "/", "-"))
@@ -61,8 +61,7 @@ func runIncusCommand(t *testing.T, ctx context.Context, projectName string, args
 func stripListOutput(t *testing.T, output *bytes.Buffer) string {
 	t.Helper()
 
-	ipRegex, err := regexp.Compile(`\d+\.\d+\.\d+\.\d+`)
-	require.NoError(t, err)
+	ipRegex := regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)
 	outStr := ipRegex.ReplaceAllString(output.String(), "-stripped-")
 
 	// // Strip health status for now, its flaky.
@@ -74,7 +73,7 @@ func stripListOutput(t *testing.T, output *bytes.Buffer) string {
 	return strings.Trim(outStr, "\n")
 }
 
-func projectClient(t *testing.T, ctx context.Context, projectName string, opts ...client.EnsureProjectOption) *client.Client {
+func projectClient(ctx context.Context, t *testing.T, projectName string, opts ...client.EnsureProjectOption) *client.Client {
 	t.Helper()
 
 	gc, err := client.NewTestClient(ctx)
@@ -89,7 +88,7 @@ func projectClient(t *testing.T, ctx context.Context, projectName string, opts .
 	return c
 }
 
-func loadProject(t *testing.T, ctx context.Context, compose string, projectName string) (*client.Client, *project.Project) {
+func loadProject(ctx context.Context, t *testing.T, compose string, projectName string) (*client.Client, *project.Project) {
 	files := []string{compose}
 	incusCFile := filepath.Join(
 		filepath.Dir(compose),
@@ -108,7 +107,7 @@ func loadProject(t *testing.T, ctx context.Context, compose string, projectName 
 	)
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, projectName,
+	c := projectClient(ctx, t, projectName,
 		client.EnsureProjectWithCreate(),
 		client.EnsureProjectWithConfig(p.ProjectConfig()),
 	)
@@ -247,7 +246,7 @@ func TestE2EHDNginx(t *testing.T) {
 	projectName := strings.ToLower(t.Name())
 	compose := "../../test/fixtures/nginx-proxy/compose.yaml"
 
-	c, p := loadProject(t, ctx, compose, projectName)
+	c, p := loadProject(ctx, t, compose, projectName)
 	err := c.Open()
 	require.NoError(t, err)
 
@@ -265,7 +264,7 @@ func TestE2EHDNginx(t *testing.T) {
 	t.Cleanup(func() {
 		_ = c.Done()
 
-		_, _, _ = runIncusCommand(t, ctx, projectName, "-f", compose, "down", "--project")
+		_, _, _ = runIncusCommand(ctx, t, projectName, "-f", compose, "down", "--project")
 		hCleanup()
 		cancel()
 	})
@@ -312,7 +311,7 @@ func TestE2EHDNginx(t *testing.T) {
 	require.NoError(t, err)
 
 	args := []string{"-f", compose, "list", "--format", "json"}
-	stdout, _, err := runIncusCommand(t, ctx, projectName, args...)
+	stdout, _, err := runIncusCommand(ctx, t, projectName, args...)
 	require.NoError(t, err)
 	snapshotter.SnapshotT(t, stripListOutput(t, stdout))
 }

--- a/cmd/ic-healthd/runner.go
+++ b/cmd/ic-healthd/runner.go
@@ -46,7 +46,7 @@ func NewRunner(cfg *Config) (*Runner, error) {
 	}, nil
 }
 
-// Run starts all health checkers and blocks until context is cancelled.
+// Run starts all health checkers and blocks until context is canceled.
 // This is the main entry point, it should never exit except the context is done.
 func (r *Runner) Run(ctx context.Context, reload <-chan struct{}) error {
 	var (
@@ -56,7 +56,7 @@ func (r *Runner) Run(ctx context.Context, reload <-chan struct{}) error {
 
 	for {
 		if conn == nil {
-			conn, err = r.connect(ctx)
+			conn, err = r.connect()
 			if err != nil {
 				slog.Error("connecting to incus", "error", err)
 
@@ -136,7 +136,7 @@ func (r *Runner) startCheckers(ctx context.Context) {
 	r.running = []context.CancelFunc{}
 
 	for name, inst := range instances {
-		chkCtx, cancel := context.WithCancel(ctx)
+		chkCtx, cancel := context.WithCancel(ctx) //nolint:gosec // cancel is stored in r.running and invoked on the next startCheckers/shutdown
 		checker := NewChecker(r.conn, name, inst)
 		go func() {
 			checker.Run(chkCtx, true, false)
@@ -151,7 +151,7 @@ func (r *Runner) startCheckers(ctx context.Context) {
 // On first run, the persisted cert is missing: we generate one, register it
 // with the one-time TrustToken, and persist it for subsequent runs.
 // On restart, the persisted cert is reused and the token (already consumed) is ignored.
-func (r *Runner) connect(ctx context.Context) (incus.InstanceServer, error) {
+func (r *Runner) connect() (incus.InstanceServer, error) {
 	// Token to register (generates KEY/CERT)
 	tokenPath := filepath.Join(r.config.SecretsDir, tokenFile)
 

--- a/cmd/incus-compose/bind_mount_test.go
+++ b/cmd/incus-compose/bind_mount_test.go
@@ -28,21 +28,21 @@ func TestBindMounts(t *testing.T) {
 	skipNotSameHost(t, gc)
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
 	t.Run("file bind-mount", func(t *testing.T) {
 		t.Parallel()
-		err := pollServiceHTTP(t, ctx, pn, compose, "file-web", "file-bind-mount-ok", 60*time.Second)
+		err := pollServiceHTTP(ctx, t, pn, compose, "file-web", "file-bind-mount-ok", 60*time.Second)
 		require.NoError(t, err)
 	})
 
 	t.Run("dir bind-mount", func(t *testing.T) {
 		t.Parallel()
-		err := pollServiceHTTP(t, ctx, pn, compose, "dir-web", "dir-bind-mount-ok", 60*time.Second)
+		err := pollServiceHTTP(ctx, t, pn, compose, "dir-web", "dir-bind-mount-ok", 60*time.Second)
 		require.NoError(t, err)
 	})
 }
@@ -64,7 +64,7 @@ func TestBindMountErrorsOnRemote(t *testing.T) {
 		t.Skip("this test requires the incus server to be on a remote host")
 	}
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.Error(t, err)
 }
 
@@ -81,21 +81,21 @@ func TestSeededBindMounts(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
 	t.Run("file bind-mount", func(t *testing.T) {
 		t.Parallel()
-		err := pollServiceHTTP(t, ctx, pn, compose, "file-web", "file-bind-mount-ok", 60*time.Second)
+		err := pollServiceHTTP(ctx, t, pn, compose, "file-web", "file-bind-mount-ok", 60*time.Second)
 		require.NoError(t, err)
 	})
 
 	t.Run("dir bind-mount", func(t *testing.T) {
 		t.Parallel()
-		err := pollServiceHTTP(t, ctx, pn, compose, "dir-web", "dir-bind-mount-ok", 60*time.Second)
+		err := pollServiceHTTP(ctx, t, pn, compose, "dir-web", "dir-bind-mount-ok", 60*time.Second)
 		require.NoError(t, err)
 	})
 }
@@ -116,30 +116,30 @@ func TestBindMountNoShift(t *testing.T) {
 	skipNotSameHost(t, gc)
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
 	// With security.shifted=false the bind mount is not id-shifted, so the host
 	// file shows up as nobody (65534) inside the unprivileged container.
-	err = pollServiceExec(t, ctx, pn, compose, "web",
+	err = pollServiceExec(ctx, t, pn, compose, "web",
 		[]string{"ls", "-ln", "/usr/share/nginx/html/index.html"}, "65534", 60*time.Second)
 	require.NoError(t, err)
 }
 
 // pollServiceHTTP execs wget inside the service's instance until the response
 // body contains want or timeout elapses.
-func pollServiceHTTP(t *testing.T, ctx context.Context, pn, compose, service, want string, timeout time.Duration) error {
-	return pollServiceExec(t, ctx, pn, compose, service,
+func pollServiceHTTP(ctx context.Context, t *testing.T, pn, compose, service, want string, timeout time.Duration) error {
+	return pollServiceExec(ctx, t, pn, compose, service,
 		[]string{"wget", "-q", "-O", "-", "http://127.0.0.1:8080/"}, want, timeout)
 }
 
 // pollServiceExec runs `incus-compose exec` for the service until stdout
 // contains want or timeout elapses. Checks before sleeping so the last attempt
 // is never skipped.
-func pollServiceExec(t *testing.T, ctx context.Context, pn, compose, service string, cmd []string, want string, timeout time.Duration) error {
+func pollServiceExec(ctx context.Context, t *testing.T, pn, compose, service string, cmd []string, want string, timeout time.Duration) error {
 	t.Helper()
 
 	args := append([]string{"-f", compose, "exec", "--no-tty", service, "--"}, cmd...)
@@ -149,7 +149,7 @@ func pollServiceExec(t *testing.T, ctx context.Context, pn, compose, service str
 	var lastErr error
 
 	for {
-		stdout, err := runCommand(t, ctx, pn, args...)
+		stdout, err := runCommand(ctx, t, pn, args...)
 		out := stdout.String()
 		if err == nil {
 			if !strings.Contains(out, want) {

--- a/cmd/incus-compose/build_linux.go
+++ b/cmd/incus-compose/build_linux.go
@@ -59,7 +59,7 @@ func newBuildCommand() *cli.Command {
 				globalClient.LogError("Getting the incus project", "error", err)
 				return errLogged.Wrap(err)
 			}
-			defer func() { _ = c.Done() }()
+			defer func() { c.WarnError(c.Done, "Failure during Client.Done()") }()
 
 			if err := c.Open(); err != nil {
 				globalClient.LogError("Opening the project client", "error", err)

--- a/cmd/incus-compose/build_test.go
+++ b/cmd/incus-compose/build_test.go
@@ -51,13 +51,13 @@ func TestBuildCommandWithBuildFixture(t *testing.T) {
 	fixture := "../../test/fixtures/with-build/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", fixture, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", fixture, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", fixture, "build")
+	_, err := runCommand(ctx, t, pn, "-f", fixture, "build")
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, pn)
+	c := projectClient(ctx, t, pn)
 
 	r, err := c.Resource(client.KindImage, "localhost/app:latest", &client.ImageConfig{})
 	require.NoError(t, err)
@@ -79,13 +79,13 @@ func TestBuildCommandWithServiceFilter(t *testing.T) {
 	fixture := "../../test/fixtures/with-build/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", fixture, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", fixture, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", fixture, "build", "app")
+	_, err := runCommand(ctx, t, pn, "-f", fixture, "build", "app")
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, pn)
+	c := projectClient(ctx, t, pn)
 	r, err := c.Resource(client.KindImage, "localhost/app:latest", &client.ImageConfig{})
 	require.NoError(t, err)
 	require.NoError(t, client.RunAction(ctx, r, client.ActionEnsure))
@@ -104,10 +104,10 @@ func TestBuildCommandWithNoBuildServices(t *testing.T) {
 	fixture := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", fixture, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", fixture, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", fixture, "build")
+	_, err := runCommand(ctx, t, pn, "-f", fixture, "build")
 	require.NoError(t, err)
 }
 
@@ -120,10 +120,10 @@ func TestBuildCommandWithNoMatchingBuildServices(t *testing.T) {
 	fixture := "../../test/fixtures/with-build/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", fixture, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", fixture, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", fixture, "build", "missing")
+	_, err := runCommand(ctx, t, pn, "-f", fixture, "build", "missing")
 	require.Error(t, err)
 }
 
@@ -144,10 +144,10 @@ func TestBuildCommandWithNonBuildServiceFilter(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", filepath.Join(dir, "compose.yaml"), "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", filepath.Join(dir, "compose.yaml"), "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", filepath.Join(dir, "compose.yaml"), "build", "sidecar")
+	_, err := runCommand(ctx, t, pn, "-f", filepath.Join(dir, "compose.yaml"), "build", "sidecar")
 	require.Error(t, err)
 }
 
@@ -170,10 +170,10 @@ func TestBuildCommandRejectsMultiplePlatforms(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", filepath.Join(dir, "compose.yaml"), "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", filepath.Join(dir, "compose.yaml"), "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", filepath.Join(dir, "compose.yaml"), "build")
+	_, err := runCommand(ctx, t, pn, "-f", filepath.Join(dir, "compose.yaml"), "build")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "build.platforms with multiple platforms is not supported")
 }
@@ -196,10 +196,10 @@ func TestBuildCommandRejectsUnsupportedPlatform(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", filepath.Join(dir, "compose.yaml"), "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", filepath.Join(dir, "compose.yaml"), "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", filepath.Join(dir, "compose.yaml"), "build")
+	_, err := runCommand(ctx, t, pn, "-f", filepath.Join(dir, "compose.yaml"), "build")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported build platform linux/unsupported")
 }
@@ -218,12 +218,12 @@ func TestBuildCommandReportsMissingBuilder(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", filepath.Join(dir, "compose.yaml"), "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", filepath.Join(dir, "compose.yaml"), "down", "--project")
 	})
 
 	_, err := runCommand(
-		t,
 		ctx,
+		t,
 		pn,
 		"-f", filepath.Join(dir, "compose.yaml"), "build", "--builder", "ic-unknown-builder",
 	)

--- a/cmd/incus-compose/config.go
+++ b/cmd/incus-compose/config.go
@@ -101,14 +101,14 @@ func newConfigCommand() *cli.Command {
 			// Determine output writer
 			writer := cmd.Root().Writer
 			if cmd.String("output") != "" {
-				fp, err := os.OpenFile(cmd.String("output"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+				fp, err := os.OpenFile(cmd.String("output"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 				if err != nil {
 					return err
 				}
 
 				writer = fp
 
-				defer fp.Close()
+				defer func() { _ = fp.Close() }()
 			}
 
 			// Handle filter-only options

--- a/cmd/incus-compose/e2e_test.go
+++ b/cmd/incus-compose/e2e_test.go
@@ -34,16 +34,16 @@ func TestE2EUpNoDeps(t *testing.T) {
 	pn := t.Name()
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach", "--no-deps", "nginx")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach", "--no-deps", "nginx")
 	require.NoError(t, err)
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "ps", "--quiet")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "ps", "--quiet")
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, pn)
+	c := projectClient(ctx, t, pn)
 	exists, err := c.InstanceExists("nginx-1")
 	require.NoError(t, err)
 	assert.True(t, exists)
@@ -70,13 +70,13 @@ func TestE2EUpDeps(t *testing.T) {
 	pn := t.Name()
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach", "nginx")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach", "nginx")
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, pn)
+	c := projectClient(ctx, t, pn)
 	exists, err := c.InstanceExists("nginx-1")
 	require.NoError(t, err)
 	assert.True(t, exists)
@@ -103,16 +103,16 @@ func TestE2EDownNoDeps(t *testing.T) {
 	pn := t.Name()
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "down", "--no-deps", "backend1")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "down", "--no-deps", "backend1")
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, pn)
+	c := projectClient(ctx, t, pn)
 	exists, err := c.InstanceExists("nginx-1")
 	require.NoError(t, err)
 	assert.True(t, exists)
@@ -139,18 +139,18 @@ func TestE2EDownDeps(t *testing.T) {
 	pn := t.Name()
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, pn)
+	c := projectClient(ctx, t, pn)
 	exists, err := c.InstanceExists("nginx-1")
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "down", "backend1")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "down", "backend1")
 	require.NoError(t, err)
 
 	exists, err = c.InstanceExists("backend2-1")
@@ -176,13 +176,13 @@ func TestE2EPsDeps(t *testing.T) {
 	pn := t.Name()
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
-	stdoutNoDeps, err := runCommand(t, ctx, pn, "-f", compose, "ps", "--services", "nginx")
+	stdoutNoDeps, err := runCommand(ctx, t, pn, "-f", compose, "ps", "--services", "nginx")
 	require.NoError(t, err)
 
 	noDeps := cleanLines(t, stdoutNoDeps.String())
@@ -190,7 +190,7 @@ func TestE2EPsDeps(t *testing.T) {
 	require.NotContains(t, noDeps, "backend1")
 	require.NotContains(t, noDeps, "backend2")
 
-	stdoutDeps, err := runCommand(t, ctx, pn, "-f", compose, "ps", "--services", "--with-deps", "nginx")
+	stdoutDeps, err := runCommand(ctx, t, pn, "-f", compose, "ps", "--services", "--with-deps", "nginx")
 	require.NoError(t, err)
 
 	withDeps := cleanLines(t, stdoutDeps.String())
@@ -214,7 +214,7 @@ func TestE2EStartStopRestartWithDeps(t *testing.T) {
 	pn := t.Name()
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -267,7 +267,7 @@ func TestE2EStartStopRestartWithDeps(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpDownGrafana(t *testing.T) {
@@ -280,7 +280,7 @@ func TestE2EUpDownGrafana(t *testing.T) {
 	compose := "../../test/fixtures/grafana/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -294,7 +294,7 @@ func TestE2EUpDownGrafana(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpUp(t *testing.T) {
@@ -307,7 +307,7 @@ func TestE2EUpUp(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -321,7 +321,7 @@ func TestE2EUpUp(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EDownDown(t *testing.T) {
@@ -334,7 +334,7 @@ func TestE2EDownDown(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -352,7 +352,7 @@ func TestE2EDownDown(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EDownProjectDeletesNetworks(t *testing.T) {
@@ -364,20 +364,20 @@ func TestE2EDownProjectDeletesNetworks(t *testing.T) {
 	pn := t.Name()
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
-	networks := plannedNetworkNames(t, ctx, pn, compose)
+	networks := plannedNetworkNames(ctx, t, pn, compose)
 	require.NotEmpty(t, networks)
 
 	cleaned := false
 	t.Cleanup(func() {
 		if !cleaned {
-			_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+			_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 		}
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, pn)
+	c := projectClient(ctx, t, pn)
 
 	for _, name := range networks {
 		conn, err := c.Connection()
@@ -386,7 +386,7 @@ func TestE2EDownProjectDeletesNetworks(t *testing.T) {
 		require.NoError(t, err, "for network %q", name)
 	}
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	require.NoError(t, err)
 	cleaned = true
 
@@ -408,7 +408,7 @@ func TestE2EUpRecreate(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -422,7 +422,7 @@ func TestE2EUpRecreate(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpUpRecreate(t *testing.T) {
@@ -435,7 +435,7 @@ func TestE2EUpUpRecreate(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -457,7 +457,7 @@ func TestE2EUpUpRecreate(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpRecreateDown(t *testing.T) {
@@ -470,7 +470,7 @@ func TestE2EUpRecreateDown(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -492,7 +492,7 @@ func TestE2EUpRecreateDown(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2ELifecycleSimpleNginx(t *testing.T) {
@@ -505,7 +505,7 @@ func TestE2ELifecycleSimpleNginx(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -556,7 +556,7 @@ func TestE2ELifecycleSimpleNginx(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpDownScale(t *testing.T) {
@@ -569,7 +569,7 @@ func TestE2EUpDownScale(t *testing.T) {
 	compose := "../../test/fixtures/nginx-scale/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -583,7 +583,7 @@ func TestE2EUpDownScale(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpDownDownscale(t *testing.T) {
@@ -596,7 +596,7 @@ func TestE2EUpDownDownscale(t *testing.T) {
 	compose := "../../test/fixtures/nginx-scale/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -610,7 +610,7 @@ func TestE2EUpDownDownscale(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpDownWithScale(t *testing.T) {
@@ -623,7 +623,7 @@ func TestE2EUpDownWithScale(t *testing.T) {
 	compose := "../../test/fixtures/nginx-scale/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -637,7 +637,7 @@ func TestE2EUpDownWithScale(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EListSnapshots(t *testing.T) {
@@ -649,11 +649,11 @@ func TestE2EListSnapshots(t *testing.T) {
 	pn := t.Name()
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -667,7 +667,7 @@ func TestE2EListSnapshots(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EExternalNetwork(t *testing.T) {
@@ -691,7 +691,7 @@ func TestE2EExternalNetwork(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -705,7 +705,7 @@ func TestE2EExternalNetwork(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpDownWithIncusOptions(t *testing.T) {
@@ -718,7 +718,7 @@ func TestE2EUpDownWithIncusOptions(t *testing.T) {
 	compose := "../../test/fixtures/with-incus-options/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -732,7 +732,7 @@ func TestE2EUpDownWithIncusOptions(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpDownWithProjectOptions(t *testing.T) {
@@ -745,7 +745,7 @@ func TestE2EUpDownWithProjectOptions(t *testing.T) {
 	compose := "../../test/fixtures/with-project-options/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -759,7 +759,7 @@ func TestE2EUpDownWithProjectOptions(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpDownWithSecrets(t *testing.T) {
@@ -772,7 +772,7 @@ func TestE2EUpDownWithSecrets(t *testing.T) {
 	compose := "../../test/fixtures/with-secrets/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -786,7 +786,7 @@ func TestE2EUpDownWithSecrets(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpDownWithSecretsVerifyFiles(t *testing.T) {
@@ -799,10 +799,10 @@ func TestE2EUpDownWithSecretsVerifyFiles(t *testing.T) {
 	compose := "../../test/fixtures/with-secrets/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
 	// Verify each secret file exists with correct perms/ownership
@@ -818,7 +818,7 @@ func TestE2EUpDownWithSecretsVerifyFiles(t *testing.T) {
 	}
 
 	for _, tc := range checks {
-		stdout, err := runCommand(t, ctx, pn, "-f", compose, "exec", "--no-tty", "app",
+		stdout, err := runCommand(ctx, t, pn, "-f", compose, "exec", "--no-tty", "app",
 			"--", "ls", "-ln", tc.path)
 		require.NoError(t, err)
 
@@ -840,7 +840,7 @@ func TestE2EUpDownWithConfigs(t *testing.T) {
 	compose := "../../test/fixtures/with-configs/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -854,7 +854,7 @@ func TestE2EUpDownWithConfigs(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestE2EUpDownWithConfigsVerifyFiles(t *testing.T) {
@@ -867,10 +867,10 @@ func TestE2EUpDownWithConfigsVerifyFiles(t *testing.T) {
 	compose := "../../test/fixtures/with-configs/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
 	// Verify each config file exists with correct perms/ownership
@@ -886,7 +886,7 @@ func TestE2EUpDownWithConfigsVerifyFiles(t *testing.T) {
 	}
 
 	for _, tc := range checks {
-		stdout, err := runCommand(t, ctx, pn, "-f", compose, "exec", "--no-tty", "app",
+		stdout, err := runCommand(ctx, t, pn, "-f", compose, "exec", "--no-tty", "app",
 			"--", "ls", "-ln", tc.path)
 		require.NoError(t, err)
 
@@ -908,24 +908,24 @@ func TestE2EDownImages(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "down")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "down")
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, pn)
+	c := projectClient(ctx, t, pn)
 	r, err := c.Resource(client.KindImage, "docker.io/nginx:alpine", &client.ImageConfig{})
 	require.NoError(t, err)
 	require.NoError(t, client.RunAction(ctx, r, client.ActionEnsure), "image should survive plain down")
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "down", "--images")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "down", "--images")
 	require.NoError(t, err)
 
 	r, err = c.Resource(client.KindImage, "docker.io/nginx:alpine", &client.ImageConfig{})
@@ -943,7 +943,7 @@ func TestE2EUpDownWithVolume(t *testing.T) {
 	compose := "../../test/fixtures/with-volume/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -957,5 +957,5 @@ func TestE2EUpDownWithVolume(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }

--- a/cmd/incus-compose/exec_test.go
+++ b/cmd/incus-compose/exec_test.go
@@ -23,10 +23,10 @@ func TestExecSelectsCorrectInstance(t *testing.T) {
 	compose := "../../test/fixtures/nginx-proxy/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -40,7 +40,7 @@ func TestExecSelectsCorrectInstance(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.service, func(t *testing.T) {
-			stdout, err := runCommand(t, ctx, pn, "-f", compose, "exec", "--no-tty", tt.service, "hostname")
+			stdout, err := runCommand(ctx, t, pn, "-f", compose, "exec", "--no-tty", tt.service, "hostname")
 			require.NoError(t, err)
 			if strings.TrimSpace(stdout.String()) != tt.wantHost {
 				t.Errorf("got hostname %q, want %q", strings.TrimSpace(stdout.String()), tt.wantHost)
@@ -62,19 +62,19 @@ func TestE2EExecRunsAsInstanceUser(t *testing.T) {
 	compose := "../../test/fixtures/with-user/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project", "--volumes")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project", "--volumes")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
 	// The write only succeeds if the process runs as 1000, since /data is owned
 	// by the shifted instance user.
-	_, err = runCommand(t, ctx, pn, "-f", compose, "exec", "--no-tty", "web",
+	_, err = runCommand(ctx, t, pn, "-f", compose, "exec", "--no-tty", "web",
 		"--", "sh", "-c", "echo hello > /data/test.txt")
 	require.NoError(t, err)
 
-	stdout, err := runCommand(t, ctx, pn, "-f", compose, "exec", "--no-tty", "web",
+	stdout, err := runCommand(ctx, t, pn, "-f", compose, "exec", "--no-tty", "web",
 		"--", "ls", "-ln", "/data/test.txt")
 	require.NoError(t, err)
 

--- a/cmd/incus-compose/healthd_down.go
+++ b/cmd/incus-compose/healthd_down.go
@@ -49,9 +49,6 @@ func newHealthdDownCommand() *cli.Command {
 
 			params := healthdParams{
 				projectName: p.Name,
-				binary:      "",
-				image:       resolveHealthdImage(cmd.String("image")),
-				timeout:     cmd.Duration("timeout"),
 			}
 
 			c, err := globalClient.EnsureProject(p.Name)

--- a/cmd/incus-compose/healthd_test.go
+++ b/cmd/incus-compose/healthd_test.go
@@ -79,7 +79,7 @@ func TestParseHealthdNetwork(t *testing.T) {
 // 	compose := "../../test/fixtures/healthd-debug/compose.yaml"
 
 // 	t.Cleanup(func() {
-// 		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+// 		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 // 	})
 
 // 	tests := []struct {
@@ -117,7 +117,7 @@ func TestParseHealthdNetwork(t *testing.T) {
 // 	}
 
 // 	for _, tt := range tests {
-// 		_, err := runCommand(t, ctx, pn, tt.args...)
+// 		_, err := runCommand(ctx, t, pn, tt.args...)
 // 		require.NoError(t, err)
 // 	}
 // }
@@ -132,10 +132,10 @@ func TestNoHealthdSkipsHealthdInstance(t *testing.T) {
 	compose := "../../test/fixtures/with-restart/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach", "--no-healthd")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach", "--no-healthd")
 	require.NoError(t, err)
 
 	gc, err := client.NewTestClient(ctx)
@@ -159,10 +159,10 @@ func TestNoHealthdWhenNotNeeded(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
 	gc, err := client.NewTestClient(ctx)

--- a/cmd/incus-compose/list.go
+++ b/cmd/incus-compose/list.go
@@ -204,12 +204,12 @@ func newListCommand() *cli.Command {
 
 			w := cmd.Root().Writer
 			if cmd.String("output") != "" {
-				fd, err := os.OpenFile(cmd.String("output"), os.O_APPEND|os.O_CREATE, 0o644)
+				fd, err := os.OpenFile(cmd.String("output"), os.O_APPEND|os.O_CREATE, 0o600)
 				if err != nil {
 					c.LogError(err.Error())
 					return errLogged.Wrap(err)
 				}
-				defer fd.Close()
+				defer c.WarnError(fd.Close, "Failure during close")
 				w = fd
 			}
 

--- a/cmd/incus-compose/logs.go
+++ b/cmd/incus-compose/logs.go
@@ -150,13 +150,17 @@ func (f *logHandler) stopStream(incusName string) {
 		return
 	}
 
-	v.(context.CancelFunc)()
+	if cancel, ok := v.(context.CancelFunc); ok {
+		cancel()
+	}
 }
 
 // stopStreams cancels all running log goroutines.
 func (f *logHandler) stopStreams() {
 	f.cancels.Range(func(key, value any) bool {
-		value.(context.CancelFunc)()
+		if cancel, ok := value.(context.CancelFunc); ok {
+			cancel()
+		}
 		f.cancels.Delete(key)
 		return true
 	})

--- a/cmd/incus-compose/main_test.go
+++ b/cmd/incus-compose/main_test.go
@@ -39,7 +39,7 @@ func skipNotSameHost(t *testing.T, gc *client.GlobalClient) {
 	}
 }
 
-func runCommand(t *testing.T, ctx context.Context, projectName string, args ...string) (*bytes.Buffer, error) {
+func runCommand(ctx context.Context, t *testing.T, projectName string, args ...string) (*bytes.Buffer, error) {
 	t.Helper()
 
 	projectName = strings.ToLower(strings.ReplaceAll(projectName, "/", "-"))
@@ -61,13 +61,11 @@ func runCommand(t *testing.T, ctx context.Context, projectName string, args ...s
 func stripListOutput(t *testing.T, output *bytes.Buffer, stripHealth bool) string {
 	t.Helper()
 
-	ipRegex, err := regexp.Compile(`\d+\.\d+\.\d+\.\d+`)
-	require.NoError(t, err)
+	ipRegex := regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)
 	outStr := ipRegex.ReplaceAllString(output.String(), "-stripped-")
 
 	if stripHealth {
-		healthRegex, err := regexp.Compile(`"health": "[a-zA-Z]+",`)
-		require.NoError(t, err)
+		healthRegex := regexp.MustCompile(`"health": "[a-zA-Z]+",`)
 		outStr = healthRegex.ReplaceAllString(outStr, `"health": "-stripped-",`)
 	}
 
@@ -75,7 +73,7 @@ func stripListOutput(t *testing.T, output *bytes.Buffer, stripHealth bool) strin
 	return strings.Trim(outStr, "\n")
 }
 
-func plannedNetworkNames(t *testing.T, ctx context.Context, projectName, compose string) []string {
+func plannedNetworkNames(ctx context.Context, t *testing.T, projectName, compose string) []string {
 	t.Helper()
 
 	projectName = strings.ToLower(strings.ReplaceAll(projectName, "/", "-"))
@@ -98,7 +96,7 @@ func plannedNetworkNames(t *testing.T, ctx context.Context, projectName, compose
 	return names
 }
 
-func projectClient(t *testing.T, ctx context.Context, projectName string, opts ...client.EnsureProjectOption) *client.Client {
+func projectClient(ctx context.Context, t *testing.T, projectName string, opts ...client.EnsureProjectOption) *client.Client {
 	t.Helper()
 
 	gc, err := client.NewTestClient(ctx)
@@ -121,10 +119,10 @@ type e2eTest struct {
 	snapStripHealth bool
 }
 
-func runE2ETests(t *testing.T, ctx context.Context, projectName string, tests []e2eTest) {
+func runE2ETests(ctx context.Context, t *testing.T, projectName string, tests []e2eTest) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stdout, err := runCommand(t, ctx, projectName, tt.args...)
+			stdout, err := runCommand(ctx, t, projectName, tt.args...)
 
 			if !tt.wantErr {
 				require.NoError(t, err)
@@ -228,7 +226,7 @@ func TestConfigCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			stdout, err := runCommand(t, context.Background(), "test-local-config", tt.args...)
+			stdout, err := runCommand(context.Background(), t, "test-local-config", tt.args...)
 
 			if tt.wantErr {
 				require.Error(t, err, "Stdout: %s", stdout.String())
@@ -283,7 +281,7 @@ func TestConfigFilterByService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			stdout, err := runCommand(t, context.Background(), "test-local-config-filter", tt.args...)
+			stdout, err := runCommand(context.Background(), t, "test-local-config-filter", tt.args...)
 			require.NoError(t, err)
 
 			if tt.fixture != "" {
@@ -304,7 +302,7 @@ func TestUpDownUpSimpleNginx(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -337,7 +335,7 @@ func TestUpDownUpSimpleNginx(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 func TestNormalLifecycle(t *testing.T) {
@@ -349,7 +347,7 @@ func TestNormalLifecycle(t *testing.T) {
 	compose := "../../test/fixtures/two-services/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -368,7 +366,7 @@ func TestNormalLifecycle(t *testing.T) {
 		},
 	}
 
-	runE2ETests(t, ctx, pn, tests)
+	runE2ETests(ctx, t, pn, tests)
 }
 
 // dnsServiceIPs aggregates the dnsmasq address records for a service across the
@@ -399,17 +397,17 @@ func TestUpDownscaleRemovesInstancesAndDNS(t *testing.T) {
 	pn := t.Name()
 	compose := "../../test/fixtures/nginx-downscale/compose.yaml"
 
-	networks := plannedNetworkNames(t, ctx, pn, compose)
+	networks := plannedNetworkNames(ctx, t, pn, compose)
 	require.NotEmpty(t, networks)
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, pn)
+	c := projectClient(ctx, t, pn)
 	for _, name := range []string{"web-1", "web-2", "web-3"} {
 		ok, err := c.InstanceExists(name)
 		require.NoError(t, err)
@@ -419,7 +417,7 @@ func TestUpDownscaleRemovesInstancesAndDNS(t *testing.T) {
 	before := dnsServiceIPs(t, c, networks, "web")
 	require.NotEmpty(t, before, "web should have DNS records for 3 replicas")
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach", "--scale=web=1")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "up", "--detach", "--scale=web=1")
 	require.NoError(t, err)
 
 	survivor, err := c.InstanceExists("web-1")
@@ -449,14 +447,14 @@ func TestUpReconcilesToReplicas(t *testing.T) {
 	compose := "../../test/fixtures/nginx-downscale/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	// Baseline: deploy.replicas=3.
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
-	c := projectClient(t, ctx, pn)
+	c := projectClient(ctx, t, pn)
 	allNames := []string{"web-1", "web-2", "web-3", "web-4", "web-5"}
 	assertCount := func(want int) {
 		t.Helper()
@@ -469,22 +467,22 @@ func TestUpReconcilesToReplicas(t *testing.T) {
 	assertCount(3)
 
 	// Manual downscale to 1.
-	_, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach", "--scale=web=1")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "up", "--detach", "--scale=web=1")
 	require.NoError(t, err)
 	assertCount(1)
 
 	// Plain up restores replicas=3 (scales back up).
-	_, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 	assertCount(3)
 
 	// Manual upscale to 5.
-	_, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach", "--scale=web=5")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "up", "--detach", "--scale=web=5")
 	require.NoError(t, err)
 	assertCount(5)
 
 	// Plain up reconciles back down to replicas=3.
-	_, err = runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 	assertCount(3)
 }

--- a/cmd/incus-compose/pull_test.go
+++ b/cmd/incus-compose/pull_test.go
@@ -13,10 +13,10 @@ import (
 
 // pulledImageAliases runs the wrapped `incus image list --format=json` inside the
 // compose project's Incus project and returns the alias names of the images found.
-func pulledImageAliases(t *testing.T, ctx context.Context, projectName, compose string) []string {
+func pulledImageAliases(ctx context.Context, t *testing.T, projectName, compose string) []string {
 	t.Helper()
 
-	stdout, err := runCommand(t, ctx, projectName, "-f", compose, "incus", "image", "list", "--format=json")
+	stdout, err := runCommand(ctx, t, projectName, "-f", compose, "incus", "image", "list", "--format=json")
 	require.NoError(t, err)
 
 	var images []struct {
@@ -55,7 +55,7 @@ func TestE2EPull(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []struct {
@@ -78,10 +78,10 @@ func TestE2EPull(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := runCommand(t, ctx, pn, tt.args...)
+			_, err := runCommand(ctx, t, pn, tt.args...)
 			require.NoError(t, err)
 
-			aliases := pulledImageAliases(t, ctx, pn, compose)
+			aliases := pulledImageAliases(ctx, t, pn, compose)
 			require.True(t, hasImage(aliases, "nginx"),
 				"expected the nginx image in the project, got %v", aliases)
 		})
@@ -100,23 +100,23 @@ func TestE2EPullWithDeps(t *testing.T) {
 	compose := "../../test/fixtures/postgres-redis/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	// Pulling just "api" copies its own image, not its dependencies.
-	_, err := runCommand(t, ctx, pn, "-f", compose, "pull", "--no-healthd", "api")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "pull", "--no-healthd", "api")
 	require.NoError(t, err)
 
-	aliases := pulledImageAliases(t, ctx, pn, compose)
+	aliases := pulledImageAliases(ctx, t, pn, compose)
 	require.True(t, hasImage(aliases, "node"), "expected the api image, got %v", aliases)
 	require.False(t, hasImage(aliases, "postgres"), "did not expect dep images, got %v", aliases)
 	require.False(t, hasImage(aliases, "redis"), "did not expect dep images, got %v", aliases)
 
 	// --with-deps follows depends_on and also pulls postgres and redis.
-	_, err = runCommand(t, ctx, pn, "-f", compose, "pull", "--no-healthd", "--with-deps", "api")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "pull", "--no-healthd", "--with-deps", "api")
 	require.NoError(t, err)
 
-	aliases = pulledImageAliases(t, ctx, pn, compose)
+	aliases = pulledImageAliases(ctx, t, pn, compose)
 	require.True(t, hasImage(aliases, "node"), "expected the api image, got %v", aliases)
 	require.True(t, hasImage(aliases, "postgres"), "expected the postgres dep image, got %v", aliases)
 	require.True(t, hasImage(aliases, "redis"), "expected the redis dep image, got %v", aliases)
@@ -140,10 +140,10 @@ func TestE2EPullInvalidImage(t *testing.T) {
 	compose := filepath.Join(dir, "compose.yaml")
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "pull")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "pull")
 	require.Error(t, err)
 }
 
@@ -159,10 +159,10 @@ func TestE2EPullIgnoreBuildable(t *testing.T) {
 	compose := "../../test/fixtures/with-build/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	// --ignore-buildable skips images with a build config, leaving nothing to pull.
-	_, err := runCommand(t, ctx, pn, "-f", compose, "pull", "--ignore-buildable")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "pull", "--ignore-buildable")
 	require.NoError(t, err)
 }

--- a/cmd/incus-compose/regression_test.go
+++ b/cmd/incus-compose/regression_test.go
@@ -20,13 +20,13 @@ func TestNoDanglingNetworksAfterDown(t *testing.T) {
 	compose := "../../test/fixtures/simple-nginx/compose.yaml"
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 
-	_, err = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+	_, err = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	require.NoError(t, err)
 
 	gc, err := client.NewTestClient(ctx)
@@ -54,7 +54,7 @@ func TestE2EStartStopIdempotent(t *testing.T) {
 	pn := t.Name()
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
 	tests := []e2eTest{
@@ -81,7 +81,7 @@ func TestE2EStartStopIdempotent(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		_, err := runCommand(t, ctx, pn, tt.args...)
+		_, err := runCommand(ctx, t, pn, tt.args...)
 		require.NoError(t, err)
 	}
 }
@@ -97,9 +97,9 @@ func TestE2ENoImageCache(t *testing.T) {
 	pn := t.Name()
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "up", "--detach", "--image-cache", "")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach", "--image-cache", "")
 	require.NoError(t, err)
 }

--- a/cmd/incus-compose/up.go
+++ b/cmd/incus-compose/up.go
@@ -244,7 +244,7 @@ func newUpCommand() *cli.Command {
 
 				rc.LogDebug("Ensure", "resources", stack.All())
 
-				recreateOptions := append(runOptions, client.OptionForce())
+				recreateOptions := append(append([]client.Option{}, runOptions...), client.OptionForce())
 
 				// Ensure without create for "recreate" (resolution only, no progress).
 				if err := ensureStack.ForAction(client.ActionEnsure).Run(ctx, client.ActionEnsure, stdout, stderr); err != nil {
@@ -347,7 +347,7 @@ func newUpCommand() *cli.Command {
 
 			// Ensure with create. --pull=always refreshes cached images from registry.
 			// policy and missing only use the local cache (pull if not present).
-			startOptions := append(runOptions, client.OptionCreate())
+			startOptions := append(append([]client.Option{}, runOptions...), client.OptionCreate())
 			if cmd.String("pull") == "always" {
 				startOptions = append(startOptions, client.OptionPull())
 			}

--- a/cmd/incus-compose/wellknown_test.go
+++ b/cmd/incus-compose/wellknown_test.go
@@ -24,10 +24,10 @@ func TestWellKnownRegistryQuayIO(t *testing.T) {
 	compose := filepath.Join(dir, "compose.yaml")
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "pull", "--no-healthd", "hello")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "pull", "--no-healthd", "hello")
 	require.NoError(t, err)
 }
 
@@ -47,9 +47,9 @@ func TestWellKnownRegistryMCR(t *testing.T) {
 	compose := filepath.Join(dir, "compose.yaml")
 
 	t.Cleanup(func() {
-		_, _ = runCommand(t, ctx, pn, "-f", compose, "down", "--project")
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
 	})
 
-	_, err := runCommand(t, ctx, pn, "-f", compose, "pull", "--no-healthd", "hello")
+	_, err := runCommand(ctx, t, pn, "-f", compose, "pull", "--no-healthd", "hello")
 	require.NoError(t, err)
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -25,7 +25,7 @@ func skipExamples(t *testing.T) {
 	}
 }
 
-func runCommand(t *testing.T, ctx context.Context, projectName string, args ...string) (*bytes.Buffer, error) {
+func runCommand(ctx context.Context, t *testing.T, projectName string, args ...string) (*bytes.Buffer, error) {
 	t.Helper()
 
 	projectName = strings.ToLower(strings.ReplaceAll(projectName, "/", "-"))
@@ -47,8 +47,7 @@ func runCommand(t *testing.T, ctx context.Context, projectName string, args ...s
 func stripListOutput(t *testing.T, output *bytes.Buffer) string {
 	t.Helper()
 
-	ipRegex, err := regexp.Compile(`\d+\.\d+\.\d+\.\d+`)
-	require.NoError(t, err)
+	ipRegex := regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)
 	outStr := ipRegex.ReplaceAllString(output.String(), "-stripped-")
 
 	// // Strip health status for now, its flaky.
@@ -104,18 +103,18 @@ func TestExample(t *testing.T) {
 
 			ctx := context.Background()
 			t.Cleanup(func() {
-				_, _ = runCommand(t, ctx, t.Name(), "--project-directory", example.dir, "down", "--project")
+				_, _ = runCommand(ctx, t, t.Name(), "--project-directory", example.dir, "down", "--project")
 			})
 
 			args := []string{"--project-directory", example.dir, "up", "--detach"}
-			_, err := runCommand(t, ctx, t.Name(), args...)
+			_, err := runCommand(ctx, t, t.Name(), args...)
 			require.NoError(t, err)
 
 			// Sometimes this is needed to get the real health status.
 			time.Sleep(1 * time.Second)
 
 			args = []string{"--project-directory", example.dir, "list", "--format", "json"}
-			stdout, err := runCommand(t, ctx, t.Name(), args...)
+			stdout, err := runCommand(ctx, t, t.Name(), args...)
 			require.NoError(t, err)
 
 			snapshotter.SnapshotT(t, stripListOutput(t, stdout))

--- a/project/instance.go
+++ b/project/instance.go
@@ -93,7 +93,7 @@ func serviceToInstance(c *client.Client, p *types.Project, serviceName string, o
 		}
 	}
 
-	volumes, files, volumeResources, err := instanceVolumeDevices(c, p, service, image, uid, gid, options)
+	volumes, files, volumeResources, err := instanceVolumeDevices(c, p, service, image, uid, gid)
 	if err != nil {
 		errs = errors.Join(errs, err)
 	}
@@ -542,8 +542,8 @@ func instanceProxyDevices(c *client.Client, service types.ServiceConfig, nicDevi
 
 // instanceVolumeDevices builds disk, bind, and tmpfs devices for a service's
 // volumes plus the shm_size tmpfs. It returns any storage volume resources
-// (when options.StorageVolumes is set) and the files map for single-file binds.
-func instanceVolumeDevices(c *client.Client, p *types.Project, service types.ServiceConfig, image client.Resource, uid, gid uint64, options *ResourcesOptions) ([]client.InstanceDevice, []client.InstanceFile, []client.Resource, error) {
+// and the files map for single-file binds.
+func instanceVolumeDevices(c *client.Client, p *types.Project, service types.ServiceConfig, image client.Resource, uid, gid uint64) ([]client.InstanceDevice, []client.InstanceFile, []client.Resource, error) {
 	var errs error
 	devices := []client.InstanceDevice{}
 	resources := []client.Resource{}
@@ -727,7 +727,7 @@ func instanceVolumeDevices(c *client.Client, p *types.Project, service types.Ser
 			}
 			devices = append(devices, client.InstanceDevice{Name: devName, Config: devConfig})
 		default:
-			err := fmt.Errorf("Unknown volume type %q for service %q", cVol.Type, service.Name)
+			err := fmt.Errorf("unknown volume type %q for service %q", cVol.Type, service.Name)
 			errs = errors.Join(errs, err)
 			continue
 		}
@@ -830,7 +830,7 @@ func instanceDependencyWaits(p *types.Project, service types.ServiceConfig, opti
 		if s, ok := options.Scale[depName]; ok {
 			depScale = s
 		} else if depSvc.Deploy != nil && depSvc.Deploy.Replicas != nil {
-			depScale = int(*depSvc.Deploy.Replicas)
+			depScale = *depSvc.Deploy.Replicas
 		}
 		if depSvc.ContainerName != "" {
 			deps[client.SanitizeIncusName(depSvc.ContainerName, client.MaxIncusNameLen)] = client.HealthStatusHealthy
@@ -1113,7 +1113,7 @@ func serviceExtraDevices(service types.ServiceConfig) ([]client.InstanceDevice, 
 	var raw map[string]any
 	ok, err := service.Extensions.Get("x-incus-compose", &raw)
 	if !ok || err != nil {
-		return nil, nil
+		return nil, nil //nolint:nilerr // missing/malformed extension means no extra devices
 	}
 
 	devicesRaw, ok := raw["devices"].(map[string]any)

--- a/project/instance_test.go
+++ b/project/instance_test.go
@@ -692,7 +692,6 @@ func TestInstanceVolumeDevices(t *testing.T) {
 	t.Parallel()
 
 	c := client.NewOfflineClient(context.Background(), "test")
-	opts := &ResourcesOptions{}
 
 	t.Run("named volume", func(t *testing.T) {
 		t.Parallel()
@@ -701,7 +700,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 			{Type: "volume", Source: "data", Target: "/data"},
 		}}
 
-		devices, files, resources, err := instanceVolumeDevices(c, p, service, nil, 0, 0, opts)
+		devices, files, resources, err := instanceVolumeDevices(c, p, service, nil, 0, 0)
 		require.NoError(t, err)
 		assert.Empty(t, files)
 		require.Len(t, devices, 1)
@@ -719,7 +718,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 			{Type: "volume", Source: "data", Target: "/data"},
 		}}
 
-		devices, _, resources, err := instanceVolumeDevices(c, p, service, nil, 0, 0, opts)
+		devices, _, resources, err := instanceVolumeDevices(c, p, service, nil, 0, 0)
 		require.NoError(t, err)
 		require.Len(t, devices, 1)
 		require.Len(t, resources, 1)
@@ -736,7 +735,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 			{Type: "volume", Source: "data", Target: "/data"},
 		}}
 
-		devices, _, resources, err := instanceVolumeDevices(c, p, service, nil, 0, 0, opts)
+		devices, _, resources, err := instanceVolumeDevices(c, p, service, nil, 0, 0)
 		require.NoError(t, err)
 		require.Len(t, devices, 1)
 		require.Len(t, resources, 1)
@@ -757,7 +756,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 			},
 		}}
 
-		devices, _, resources, err := instanceVolumeDevices(c, p, service, nil, 0, 0, opts)
+		devices, _, resources, err := instanceVolumeDevices(c, p, service, nil, 0, 0)
 		require.NoError(t, err)
 		require.Len(t, devices, 1)
 		require.Len(t, resources, 1)
@@ -776,7 +775,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 			{Type: "volume", Source: "data", Target: "/data"},
 		}}
 
-		devices, _, resources, err := instanceVolumeDevices(c, p, service, nil, 0, 0, opts)
+		devices, _, resources, err := instanceVolumeDevices(c, p, service, nil, 0, 0)
 		require.NoError(t, err)
 		require.Len(t, devices, 1)
 		require.Len(t, resources, 1)
@@ -795,7 +794,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 			},
 		}}
 
-		devices, files, resources, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0, opts)
+		devices, files, resources, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0)
 		require.NoError(t, err)
 		assert.Empty(t, devices)
 		assert.Empty(t, resources)
@@ -821,7 +820,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 			},
 		}}
 
-		devices, files, resources, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0, opts)
+		devices, files, resources, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0)
 		require.NoError(t, err)
 		assert.Empty(t, files)
 		require.Len(t, devices, 1)
@@ -838,7 +837,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 			{Type: "bind", Source: dir, Target: "/mnt", Extensions: types.Extensions{"x-incus": map[string]any{"security.shifted": "false"}}},
 		}}
 
-		devices, _, _, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0, opts)
+		devices, _, _, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0)
 		require.NoError(t, err)
 		require.Len(t, devices, 1)
 		assert.Equal(t, client.InstanceDeviceTypeDisk, devices[0].Config.DeviceType)
@@ -851,7 +850,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 			{Type: "tmpfs", Target: "/cache"},
 		}}
 
-		devices, _, _, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0, opts)
+		devices, _, _, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0)
 		require.NoError(t, err)
 		require.Len(t, devices, 1)
 		assert.Equal(t, client.InstanceDeviceTypeTmpfs, devices[0].Config.DeviceType)
@@ -865,7 +864,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 			{Type: "bind", Source: dir, Target: "/mnt"},
 		}}
 
-		devices, files, resources, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0, opts)
+		devices, files, resources, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0)
 		require.NoError(t, err)
 		assert.Empty(t, files)
 		require.Len(t, devices, 1)
@@ -878,7 +877,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 		service := types.ServiceConfig{Name: "web", Volumes: []types.ServiceVolumeConfig{
 			{Type: "weird", Source: "x", Target: "/y"},
 		}}
-		_, _, _, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0, opts)
+		_, _, _, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0)
 		require.Error(t, err)
 	})
 
@@ -887,7 +886,7 @@ func TestInstanceVolumeDevices(t *testing.T) {
 		service := types.ServiceConfig{Name: "web", Volumes: []types.ServiceVolumeConfig{
 			{Type: "bind", Source: filepath.Join(t.TempDir(), "nope"), Target: "/m"},
 		}}
-		_, _, _, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0, opts)
+		_, _, _, err := instanceVolumeDevices(c, &types.Project{}, service, nil, 0, 0)
 		require.Error(t, err)
 	})
 }

--- a/project/project.go
+++ b/project/project.go
@@ -194,7 +194,7 @@ func (p *Project) InstanceNames() []string {
 
 		replicas := 1
 		if service.Deploy != nil && service.Deploy.Replicas != nil {
-			replicas = int(*service.Deploy.Replicas)
+			replicas = *service.Deploy.Replicas
 		}
 
 		for i := 1; i <= replicas; i++ {
@@ -284,7 +284,7 @@ func (p *Project) Resources(c *client.Client, opts ...ResourcesOption) (map[stri
 		if s, ok := options.Scale[service.Name]; ok {
 			desired = s
 		} else if service.Deploy != nil && service.Deploy.Replicas != nil {
-			desired = int(*service.Deploy.Replicas)
+			desired = *service.Deploy.Replicas
 		}
 
 		// Discover existing instances above the desired count so they can be
@@ -296,7 +296,7 @@ func (p *Project) Resources(c *client.Client, opts ...ResourcesOption) (map[stri
 				break
 			}
 
-			scale = scale + 1
+			scale++
 		}
 
 		instances := []*client.Instance{}
@@ -349,7 +349,7 @@ func ServiceGraph(serviceConfigs types.Services, reverse bool) ([]string, error)
 			}
 			// Edge from dependency to dependent (dep must start before n)
 			err := g.AddEdge(dep, s.Name)
-			if err != nil && err != graph.ErrEdgeAlreadyExists {
+			if err != nil && !errors.Is(err, graph.ErrEdgeAlreadyExists) {
 				return nil, fmt.Errorf("adding dependency edge %s -> %s: %w", dep, s.Name, err)
 			}
 		}
@@ -380,13 +380,16 @@ func buildProjectOptions(options LoadOptions, extraOpts ...cli.ProjectOptionsFn)
 		projectOptions = append(projectOptions, cli.WithOsEnv)
 	}
 
-	// Load .env files with OS env available for interpolation but not added to project
+	// Load .env files with OS env available for interpolation but not added to project.
+	// cli.WithDefaultConfigPath resolves the working directory from the discovered
+	// compose file when options.WorkingDir wasn't set, so the env file options are
+	// deliberately re-applied afterwards to resolve relative paths against it.
+	//nolint:gocritic // intentional re-application after working dir resolution, not a copy/paste duplicate
 	projectOptions = append(projectOptions,
 		cli.WithEnvFiles(options.EnvFiles...),
 		withDotEnvAndOsEnv, // Custom handler: uses OS env for interpolation only
 		cli.WithConfigFileEnv,
 		cli.WithDefaultConfigPath,
-		// Apply env files again after working dir is determined
 		cli.WithEnvFiles(options.EnvFiles...),
 		withDotEnvAndOsEnv,
 	)


### PR DESCRIPTION
Clear the ~140 findings that set turned up: real bugs (slice-aliasing in up.go's option building, a symlink TOCTOU in the storage-volume walk, a stale goimports path), dead parameters, and the mechanical stuff (error-string casing, context-as-argument ordering across test helpers, unnecessary conversions).