### PR TITLE
fix(project): use static NIC IP for NAT proxy connect address

### DIFF
--- a/cmd/incus-compose/nat_proxy_test.go
+++ b/cmd/incus-compose/nat_proxy_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2ENATProxyWithPort(t *testing.T) {
+	t.Parallel()
+	skipLocal(t)
+	skipE2E(t)
+
+	ctx := context.Background()
+	pn := t.Name()
+
+	dir := writeTempFiles(t, map[string]string{
+		"compose.yaml": `services:
+  web:
+    image: docker.io/nginx:alpine
+    ports:
+      - "8080:80"
+`,
+	})
+	compose := filepath.Join(dir, "compose.yaml")
+
+	t.Cleanup(func() {
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
+	})
+
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
+	require.NoError(t, err)
+
+	c := projectClient(ctx, t, pn)
+	conn, err := c.Connection()
+	require.NoError(t, err)
+
+	inst, _, err := conn.GetInstance("web-1")
+	require.NoError(t, err)
+
+	proxy, ok := inst.Devices["proxy-8080"]
+	require.True(t, ok, "proxy-8080 device should exist")
+	assert.Contains(t, proxy["connect"], "0.0.0.0:80")
+	assert.Equal(t, "true", proxy["nat"])
+}
+
+func TestE2ENATProxyWithPortAndStaticIP(t *testing.T) {
+	t.Parallel()
+	skipLocal(t)
+	skipE2E(t)
+
+	ctx := context.Background()
+	pn := t.Name()
+
+	dir := writeTempFiles(t, map[string]string{
+		"compose.yaml": `services:
+  web:
+    image: docker.io/nginx:alpine
+    ports:
+      - "8080:80"
+    networks:
+      frontend:
+        ipv4_address: 10.131.245.2
+
+networks:
+  frontend:
+    x-incus:
+      ipv4.address: 10.131.245.1/24
+`,
+	})
+	compose := filepath.Join(dir, "compose.yaml")
+
+	t.Cleanup(func() {
+		_, _ = runCommand(ctx, t, pn, "-f", compose, "down", "--project")
+	})
+
+	_, err := runCommand(ctx, t, pn, "-f", compose, "up", "--detach")
+	require.NoError(t, err)
+
+	c := projectClient(ctx, t, pn)
+	conn, err := c.Connection()
+	require.NoError(t, err)
+
+	inst, _, err := conn.GetInstance("web-1")
+	require.NoError(t, err)
+
+	proxy, ok := inst.Devices["proxy-8080"]
+	require.True(t, ok, "proxy-8080 device should exist")
+	assert.Contains(t, proxy["connect"], "10.131.245.2:80")
+	assert.Equal(t, "true", proxy["nat"])
+}

--- a/project/instance.go
+++ b/project/instance.go
@@ -67,7 +67,27 @@ func serviceToInstance(c *client.Client, p *types.Project, serviceName string, o
 	resources = append(resources, networks...)
 
 	nat := c.Global().ServerVersionAtLeast(7, 0)
-	proxies, err := instanceProxyDevices(nat, service)
+
+	var connectAddr string
+	if nat {
+		for _, dev := range devices {
+			if dev.Config.DeviceType != client.InstanceDeviceTypeNic {
+				continue
+			}
+			if dev.Config.Ipv4Address != "" {
+				connectAddr, _, _ = strings.Cut(dev.Config.Ipv4Address, "/")
+				break
+			}
+			if dev.Config.Extensions != nil {
+				if addr, ok := dev.Config.Extensions["ipv4.address"]; ok {
+					connectAddr, _, _ = strings.Cut(addr, "/")
+					break
+				}
+			}
+		}
+	}
+
+	proxies, err := instanceProxyDevices(nat, connectAddr, service)
 	if err != nil {
 		errs = errors.Join(errs, err)
 	}
@@ -379,16 +399,19 @@ func serviceNetworkGateway(sNet *types.ServiceNetworkConfig) bool {
 }
 
 // instanceProxyDevices builds proxy devices for every published port.
-// When nat is true the device uses Incus 7.0+ NAT proxy with ARP/NDP-based
-// instance IP detection (connect 0.0.0.0). Otherwise it falls back to a
-// userspace proxy targeting the container loopback (connect 127.0.0.1).
-func instanceProxyDevices(nat bool, service types.ServiceConfig) ([]client.InstanceDevice, error) {
+// When nat is true and connectAddr is non-empty it is used directly; when
+// nat is true and connectAddr is empty the device uses Incus 7.0+ NAT proxy
+// with ARP/NDP-based instance IP detection (connect 0.0.0.0). When nat is
+// false it falls back to a userspace proxy targeting the container loopback
+// (connect 127.0.0.1).
+func instanceProxyDevices(nat bool, connectAddr string, service types.ServiceConfig) ([]client.InstanceDevice, error) {
 	var errs error
 	devices := []client.InstanceDevice{}
 
-	connectAddr := "0.0.0.0"
 	if !nat {
 		connectAddr = "127.0.0.1"
+	} else if connectAddr == "" {
+		connectAddr = "0.0.0.0"
 	}
 
 	for _, port := range service.Ports {

--- a/project/instance_test.go
+++ b/project/instance_test.go
@@ -648,13 +648,13 @@ func TestInstanceNetworkDevices(t *testing.T) {
 func TestInstanceProxyDevices(t *testing.T) {
 	t.Parallel()
 
-	t.Run("published port with nat", func(t *testing.T) {
+	t.Run("published port with nat no static IP", func(t *testing.T) {
 		t.Parallel()
 		service := types.ServiceConfig{Name: "web", Ports: []types.ServicePortConfig{
 			{Published: "8080", Target: 80, Protocol: "tcp"},
 		}}
 
-		devices, err := instanceProxyDevices(true, service)
+		devices, err := instanceProxyDevices(true, "", service)
 		require.NoError(t, err)
 		require.Len(t, devices, 1)
 		assert.Equal(t, "proxy-8080", devices[0].Name)
@@ -666,13 +666,31 @@ func TestInstanceProxyDevices(t *testing.T) {
 		assert.True(t, proxy.Nat)
 	})
 
+	t.Run("published port with nat and static IP", func(t *testing.T) {
+		t.Parallel()
+		service := types.ServiceConfig{Name: "web", Ports: []types.ServicePortConfig{
+			{Published: "8080", Target: 80, Protocol: "tcp"},
+		}}
+
+		devices, err := instanceProxyDevices(true, "10.0.0.100", service)
+		require.NoError(t, err)
+		require.Len(t, devices, 1)
+		assert.Equal(t, "proxy-8080", devices[0].Name)
+		proxy := devices[0].Config.Proxy
+		assert.Equal(t, "0.0.0.0", proxy.ListenAddr)
+		assert.Equal(t, uint32(8080), proxy.ListenPort)
+		assert.Equal(t, "10.0.0.100", proxy.ConnectAddr)
+		assert.Equal(t, uint32(80), proxy.ConnectPort)
+		assert.True(t, proxy.Nat)
+	})
+
 	t.Run("published port without nat", func(t *testing.T) {
 		t.Parallel()
 		service := types.ServiceConfig{Name: "web", Ports: []types.ServicePortConfig{
 			{Published: "8080", Target: 80, Protocol: "tcp"},
 		}}
 
-		devices, err := instanceProxyDevices(false, service)
+		devices, err := instanceProxyDevices(false, "", service)
 		require.NoError(t, err)
 		require.Len(t, devices, 1)
 		assert.Equal(t, "proxy-8080", devices[0].Name)
@@ -689,14 +707,14 @@ func TestInstanceProxyDevices(t *testing.T) {
 		service := types.ServiceConfig{Name: "web", Ports: []types.ServicePortConfig{
 			{Published: "not-a-port", Target: 80},
 		}}
-		_, err := instanceProxyDevices(false, service)
+		_, err := instanceProxyDevices(false, "", service)
 		require.Error(t, err)
 	})
 
 	t.Run("no ports", func(t *testing.T) {
 		t.Parallel()
 		service := types.ServiceConfig{Name: "web"}
-		devices, err := instanceProxyDevices(false, service)
+		devices, err := instanceProxyDevices(false, "", service)
 		require.NoError(t, err)
 		assert.Empty(t, devices)
 	})


### PR DESCRIPTION
When a NIC has a static IPv4 address (via Compose ipv4_address or x-incus), use it directly as the proxy connect address instead of 0.0.0.0. This avoids ARP/NDP detection failures with static IPs while preserving wildcard detection for dynamic IPs.

closes #75 