### PR TITLE
healthd: use GlobalConnection() when creating trust token

### DIFF
--- a/cmd/incus-compose/healthd.go
+++ b/cmd/incus-compose/healthd.go
@@ -50,7 +50,7 @@ func healthdCreateToken(c *client.Client) (string, error) {
 		Token: true,
 	}
 
-	conn, err := c.Connection()
+	conn, err := c.GlobalConnection()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
`healthdCreateToken()` mints the trust token via `c.Connection()`, which is project-scoped. The redemption side in `ic-healthd` redeems against an unscoped connection, causing Incus to look in two different places for the pending operation and fail with "No matching certificate add operation found".

Using `c.GlobalConnection()` matches `healthdRevokeCert()` and ensures the token is created unscoped so redemption succeeds.