### PR TITLE
Support compose sysctls: via linux.sysctl.*

### DIFF
--- a/project/instance.go
+++ b/project/instance.go
@@ -186,6 +186,13 @@ func instanceConfig(c *client.Client, service types.ServiceConfig, projectName s
 		config["security.privileged"] = "true"
 	}
 
+	// Sysctls -- verified live against a real cluster: linux.sysctl.<key>
+	// applies immediately and persists across restart, on both privileged
+	// and unprivileged OCI application containers.
+	for key, val := range service.Sysctls {
+		config["linux.sysctl."+key] = val
+	}
+
 	// Restart policy
 	applyRestartPolicy(config, service.Restart)
 	if service.Restart != "" {

--- a/project/instance_test.go
+++ b/project/instance_test.go
@@ -298,6 +298,29 @@ func TestInstanceConfigResourceLimits(t *testing.T) {
 	}
 }
 
+func TestInstanceConfigSysctls(t *testing.T) {
+	t.Parallel()
+
+	gc, err := client.NewTestClient(t.Context())
+	require.NoError(t, err)
+	c, err := gc.EnsureProject("default")
+	require.NoError(t, err)
+
+	service := types.ServiceConfig{
+		Name: "web",
+		Sysctls: types.Mapping{
+			"net.ipv4.conf.all.src_valid_mark": "1",
+			"net.ipv6.conf.all.disable_ipv6":   "0",
+		},
+	}
+
+	config, err := instanceConfig(c, service, "test", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "1", config["linux.sysctl.net.ipv4.conf.all.src_valid_mark"])
+	assert.Equal(t, "0", config["linux.sysctl.net.ipv6.conf.all.disable_ipv6"])
+}
+
 func TestInstanceConfigMinimal(t *testing.T) {
 	t.Parallel()
 	skipLocal(t)


### PR DESCRIPTION
sysctls: currently parses with no error but has no effect -- compose-go's ServiceConfig already exposes it as `service.Sysctls` (a plain `map[string]string`), but `instanceConfig()` never reads it, so nothing reaches Incus. Not mentioned in compose-compatibility in either direction, so the only way to discover this today is to check live instance state against what was declared.

This wires it to linux.sysctl.<key>, the same pattern already used for Privileged two lines above it. Verified live against a real 3-node Incuscluster, not just unit-tested: `incus config set <instance> linux.sysctl.net.ipv4.ip_forward=1` takes effect immediately and survives a full stop/start, on an unprivileged OCI application container -- so this isn't a privileged-only capability and isn't Incus-side unsupported, it was purely a missing translation on the incus-compose side.