### PR TITLE
fix: correct operator precedence in x-incus-compose gateway check

### DIFF
--- a/project/instance.go
+++ b/project/instance.go
@@ -394,8 +394,8 @@ func instanceNetworkDevices(c *client.Client, p *types.Project, service types.Se
 				Internal bool  `mapstructure:"internal"`
 				Gateway  *bool `mapstructure:"gateway"`
 			}
-			ok, err := sNet.Extensions.Get("x-incus-compose", &ext)
-			if ok || err == nil && ext.Internal {
+			_, err := sNet.Extensions.Get("x-incus-compose", &ext)
+			if err == nil && ext.Internal {
 				gateway4 = "none"
 				gateway6 = "none"
 			}

--- a/project/instance_test.go
+++ b/project/instance_test.go
@@ -964,6 +964,50 @@ func TestInstanceNetworkDevices(t *testing.T) {
 		assert.Contains(t, err.Error(), "with no address")
 	})
 
+	t.Run("a non-internal x-incus-compose key does not force gateway=none", func(t *testing.T) {
+		t.Parallel()
+		skipNo73(t, c)
+
+		p := &types.Project{Networks: types.Networks{
+			"frontend": {Extensions: types.Extensions{"x-incus": map[string]any{
+				"ipv4.address": "10.0.1.1/24",
+			}}},
+		}}
+		service := types.ServiceConfig{Name: "web", Networks: map[string]*types.ServiceNetworkConfig{
+			"frontend": {
+				Ipv4Address: "10.0.1.5",
+				Extensions:  types.Extensions{"x-incus-compose": map[string]any{"network": "somebridge"}},
+			},
+		}}
+
+		devices, _, err := instanceNetworkDevices(c, p, service, "")
+		require.NoError(t, err)
+		require.Len(t, devices, 1)
+		assert.Equal(t, "10.0.1.1", devices[0].Config.Extensions["ipv4.gateway"])
+	})
+
+	t.Run("internal true still forces gateway=none", func(t *testing.T) {
+		t.Parallel()
+		skipNo73(t, c)
+
+		p := &types.Project{Networks: types.Networks{
+			"frontend": {Extensions: types.Extensions{"x-incus": map[string]any{
+				"ipv4.address": "10.0.1.1/24",
+			}}},
+		}}
+		service := types.ServiceConfig{Name: "web", Networks: map[string]*types.ServiceNetworkConfig{
+			"frontend": {
+				Ipv4Address: "10.0.1.5",
+				Extensions:  types.Extensions{"x-incus-compose": map[string]any{"internal": true}},
+			},
+		}}
+
+		devices, _, err := instanceNetworkDevices(c, p, service, "")
+		require.NoError(t, err)
+		require.Len(t, devices, 1)
+		assert.Equal(t, "none", devices[0].Config.Extensions["ipv4.gateway"])
+	})
+
 	t.Run("an external network is named by its compose name", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Extensions.Get returns ok=true whenever the x-incus-compose key is present, regardless of its content, so ok || err == nil && ext.Internal forced gateway=none on any network attachment carrying that key at all. The intended condition is just err == nil && ext.Internal; ok is redundant once that is written out.