### PR TITLE
Pull always recreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ for correct semver ordering. Headings below preserve each release's announced fo
   Waiting for a container's IP now reports a clearer timeout, naming the
   likely cause and a command to check it. (by @jochumdev)
 
+- `up --pull always` recreates a service whose image the pull replaced, the way
+  `up --build` recreates one whose image was rebuilt. A pulled image reaches an
+  instance only when it is created from it, so a newer one sat in the image
+  store unused unless `--recreate` came along too. Only `--pull always`
+  recreates: a service already running the image it was created from, and every
+  other pull policy, are left alone. (by @alien43)
+
 ### Fixed
 
 - A service `user:` may now name its user and group, not only number them:

--- a/cmd/incus-compose/e2e_test.go
+++ b/cmd/incus-compose/e2e_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -980,4 +981,88 @@ func TestE2EUpReconcilesToReplicas(t *testing.T) {
 	_, err = testlib.RunCompose(ctx, t, pn, "", nil, "-f", compose, "up", "--detach")
 	require.NoError(t, err)
 	assertCount(3)
+}
+
+// TestE2EUpPullAlwaysRecreates pins that --pull always replaces an instance
+// whose image moved under it, and that every other policy leaves it alone.
+func TestE2EUpPullAlwaysRecreates(t *testing.T) {
+	t.Parallel()
+	testlib.SkipLocal(t)
+	testlib.SkipE2E(t)
+
+	ctx := t.Context()
+	pn := t.Name()
+
+	// Two tags of one image, so the fingerprint the pull lands differs.
+	dir := testlib.WriteTempFiles(t, map[string]string{
+		"compose.yaml": `services:
+  web:
+    image: docker.io/library/busybox:1.36-glibc
+    x-incus:
+      oci.entrypoint: sh
+`,
+		"compose-new.yaml": `services:
+  web:
+    image: docker.io/library/busybox:1.37-glibc
+    x-incus:
+      oci.entrypoint: sh
+`,
+	})
+	oldCompose := filepath.Join(dir, "compose.yaml")
+	newCompose := filepath.Join(dir, "compose-new.yaml")
+
+	testlib.CleanupCompose(t, pn, "-f", oldCompose, "down", "--project")
+
+	runE2ETests(ctx, t, pn, []e2eTest{
+		{
+			name: "up on the old image",
+			args: []string{"-f", oldCompose, "up", "--detach"},
+		},
+	})
+
+	c := projectClient(ctx, t, pn)
+	conn, err := c.Connection()
+	require.NoError(t, err)
+
+	inst, _, err := conn.GetInstance(ctx, "web-1", nil)
+	require.NoError(t, err)
+
+	created := inst.Config["volatile.base_image"]
+	require.NotEmpty(t, created)
+
+	runE2ETests(ctx, t, pn, []e2eTest{
+		{
+			name: "up on the new image without a pull policy",
+			args: []string{"-f", newCompose, "up", "--detach"},
+		},
+	})
+
+	inst, _, err = conn.GetInstance(ctx, "web-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, created, inst.Config["volatile.base_image"], "only --pull always recreates")
+
+	runE2ETests(ctx, t, pn, []e2eTest{
+		{
+			name: "up on the new image with --pull always",
+			args: []string{"-f", newCompose, "up", "--detach", "--pull", "always"},
+		},
+	})
+
+	inst, _, err = conn.GetInstance(ctx, "web-1", nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, created, inst.Config["volatile.base_image"], "the replaced image must reach the instance")
+	assert.Equal(t, "Running", inst.Status)
+
+	pulled := inst.Config["volatile.base_image"]
+
+	runE2ETests(ctx, t, pn, []e2eTest{
+		{
+			name: "up again with --pull always",
+			args: []string{"-f", newCompose, "up", "--detach", "--pull", "always"},
+		},
+	})
+
+	inst, _, err = conn.GetInstance(ctx, "web-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, pulled, inst.Config["volatile.base_image"], "an unchanged image must not recreate")
 }

--- a/cmd/incus-compose/pull.go
+++ b/cmd/incus-compose/pull.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"time"
 
@@ -9,7 +10,109 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/lxc/incus-compose/client"
+	"github.com/lxc/incus-compose/project"
 )
+
+// pullArgs holds the pull() options, mirroring the pull command's flags.
+type pullArgs struct {
+	Services           []string
+	WithDeps           bool
+	IgnoreBuildable    bool
+	IgnorePullFailures bool
+	NoHealthd          bool
+	HealthdImage       string
+	Pull               client.PullMode
+	Scale              map[string]int
+	Workers            int
+	Debug              bool
+	Writer             io.Writer
+}
+
+// pull fetches the images of the project's services.
+func pull(ctx context.Context, p *project.Project, c *client.Client, args pullArgs) error {
+	noColor := noColor(ctx)
+
+	if !args.Debug {
+		progress := newProgressRenderer(args.Writer, noColor, isatty.IsTerminal(os.Stdout.Fd()))
+		progress.Start(c)
+		defer progress.Stop(c)
+	}
+
+	resources, err := p.Resources(c, project.ResourcesScale(args.Scale))
+	if err != nil {
+		c.LogError("Getting project resources in reCreate", "error", err)
+		return errLogged.Wrap(err)
+	}
+
+	filterArgs := filterResourcesArgs{
+		OnlyServices:     args.Services,
+		WithDependencies: args.WithDeps,
+		IncludeKinds:     []client.Kind{client.KindImage},
+	}
+	myResources := filterResources(p, resources, filterArgs)
+
+	var stack *client.Stack
+	if args.IgnorePullFailures {
+		stack = client.NewStack(c, client.StackWorkers(args.Workers))
+	} else {
+		stack = client.NewStack(c, client.StackWorkers(args.Workers), client.StackFailFast())
+	}
+
+	for _, res := range myResources {
+		for _, r := range res {
+			if !args.IgnoreBuildable {
+				stack.Add(r)
+				continue
+			}
+
+			i, ok := r.(*client.Image)
+			if !ok {
+				continue
+			}
+
+			// Ignore images with a build config.
+			if i.Config.Build == nil {
+				stack.Add(i)
+			}
+		}
+	}
+
+	if !args.NoHealthd && healthdInUseByProject(c.Global(), p) {
+		hparams := healthdParams{
+			binary:       "",
+			image:        resolveHealthdImage(args.HealthdImage),
+			incus:        nil,
+			network:      "",
+			timeout:      time.Second,
+			stackWorkers: args.Workers,
+		}
+
+		_, hResources, err := healthdGetResources(c, hparams)
+		if err != nil {
+			c.LogError("Creating healthd resources", "error", err)
+			return errLogged.Wrap(err)
+		}
+
+		for _, r := range hResources {
+			if r.Kind() == client.KindImage {
+				stack.Add(r)
+			}
+		}
+	}
+
+	err = stack.ForAction(client.ActionEnsure).Run(
+		ctx,
+		client.ActionEnsure,
+		client.OptionPullMode(args.Pull),
+		client.OptionCreate(),
+	)
+	if err != nil {
+		c.LogError("Getting resources", "error", err)
+		return errLogged.Wrap(err)
+	}
+
+	return nil
+}
 
 func newPullCommand() *cli.Command {
 	return &cli.Command{
@@ -53,10 +156,6 @@ func newPullCommand() *cli.Command {
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			noColor := noColor(ctx)
-
-			withDeps := cmd.Bool("include-deps")
-
 			p, c, err := loadProject(ctx, cmd, client.EnsureProjectWithCreate())
 			if err != nil {
 				return err
@@ -69,81 +168,10 @@ func newPullCommand() *cli.Command {
 			}
 			defer c.WarnError(c.Done, "Failure during Client.Done()")
 
-			if !cmd.Root().Bool("debug") {
-				progress := newProgressRenderer(cmd.Root().Writer, noColor, isatty.IsTerminal(os.Stdout.Fd()))
-				progress.Start(c)
-				defer progress.Stop(c)
-			}
-
-			// Register the DNS Watcher after the progress renderer so progress waits for the dns changes.
+			// RegisterDNSWatcher is not idempotent, so pull() leaves it to its callers.
 			if err := c.RegisterDNSWatcher(); err != nil {
 				c.LogError("Registering the DNS watcher", "project", p.Name, "error", err)
 				return errLogged.Wrap(err)
-			}
-
-			resources, err := p.Resources(c)
-			if err != nil {
-				c.LogError("Getting project resources in reCreate", "error", err)
-				return errLogged.Wrap(err)
-			}
-
-			args := filterResourcesArgs{
-				OnlyServices:     cmd.Args().Slice(),
-				WithDependencies: withDeps,
-			}
-			myResources := filterResources(p, resources, args)
-
-			var stack *client.Stack
-			if cmd.Bool("ignore-pull-failures") {
-				stack = client.NewStack(c, client.StackWorkers(cmd.Root().Int("workers")))
-			} else {
-				stack = client.NewStack(c, client.StackWorkers(cmd.Root().Int("workers")), client.StackFailFast())
-			}
-
-			for _, res := range myResources {
-				for _, r := range res {
-					if r.Kind() != client.KindImage {
-						continue
-					}
-
-					if !cmd.Bool("ignore-buildable") {
-						stack.Add(r)
-					} else {
-						i, ok := r.(*client.Image)
-						if !ok {
-							continue
-						}
-
-						// Ignore images with a build config.
-						if i.Config.Build == nil {
-							stack.Add(i)
-						}
-					}
-				}
-			}
-
-			if !cmd.Bool("no-healthd") && healthdInUseByProject(c.Global(), p) {
-				hparams := healthdParams{
-					binary:       "",
-					image:        resolveHealthdImage(cmd.String("healthd-image")),
-					pull:         cmd.String("policy"),
-					incus:        nil,
-					network:      "",
-					timeout:      time.Second,
-					stackWorkers: cmd.Root().Int("workers"),
-				}
-
-				_, hResources, err := healthdGetResources(c, hparams)
-				if err != nil {
-					c.LogError("Creating healthd resources", "error", err)
-					return errLogged.Wrap(err)
-				}
-
-				for _, r := range hResources {
-					if r.Kind() == client.KindImage {
-						stack.Add(r)
-					}
-				}
 			}
 
 			// Anything unknown keeps the flag's "always" default.
@@ -155,18 +183,18 @@ func newPullCommand() *cli.Command {
 				pullMode = client.PullNever
 			}
 
-			err = stack.ForAction(client.ActionEnsure).Run(
-				ctx,
-				client.ActionEnsure,
-				client.OptionPullMode(pullMode),
-				client.OptionCreate(),
-			)
-			if err != nil {
-				c.LogError("Getting resources", "error", err)
-				return errLogged.Wrap(err)
-			}
-
-			return nil
+			return pull(ctx, p, c, pullArgs{
+				Services:           cmd.Args().Slice(),
+				WithDeps:           cmd.Bool("include-deps"),
+				IgnoreBuildable:    cmd.Bool("ignore-buildable"),
+				IgnorePullFailures: cmd.Bool("ignore-pull-failures"),
+				NoHealthd:          cmd.Bool("no-healthd"),
+				HealthdImage:       cmd.String("healthd-image"),
+				Pull:               pullMode,
+				Workers:            cmd.Root().Int("workers"),
+				Debug:              cmd.Root().Bool("debug"),
+				Writer:             cmd.Root().Writer,
+			})
 		},
 	}
 }

--- a/cmd/incus-compose/up.go
+++ b/cmd/incus-compose/up.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	incusApi "github.com/lxc/incus/v7/shared/api"
 	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v3"
 
@@ -214,14 +215,59 @@ func newUpCommand() *cli.Command {
 				WithDependencies: !cmd.Bool("no-deps"),
 			}
 
-			// A rebuilt image only reaches an instance created from it again.
+			// "missing" and the legacy "policy" are the default, as is anything unknown.
+			pullMode := client.PullMissing
+			switch cmd.String("pull") {
+			case "always":
+				pullMode = client.PullAlways
+			case "never":
+				pullMode = client.PullNever
+			}
+
+			// The stale set below needs the images pulled first; built ones stay
+			// with builtServices and healthd pulls its own in healthdUp.
+			err = pull(ctx, p, c, pullArgs{
+				Services:        cmd.Args().Slice(),
+				WithDeps:        !cmd.Bool("no-deps"),
+				IgnoreBuildable: true,
+				NoHealthd:       true,
+				Pull:            pullMode,
+				Scale:           scale,
+				Workers:         cmd.Root().Int("workers"),
+				Debug:           cmd.Root().Bool("debug"),
+				Writer:          cmd.Root().Writer,
+			})
+			if err != nil {
+				return err
+			}
+
+			// A rebuilt or re-pulled image only reaches an instance created from it again.
 			recreate := cmd.Bool("recreate")
 			downServices, downNoDeps := cmd.Args().Slice(), cmd.Bool("no-deps")
-			if !recreate && buildMode == client.BuildForce {
-				downServices = builtServices(p, args)
+			if !recreate {
+				stale := []string{}
+				if buildMode == client.BuildForce {
+					stale = builtServices(p, args)
+				}
+
+				if pullMode == client.PullAlways {
+					pulled, err := pulledServices(ctx, p, c, args, pullMode, scale)
+					if err != nil {
+						c.LogError("Comparing the instance images against the pulled ones", "error", err)
+						return errLogged.Wrap(err)
+					}
+
+					stale = append(stale, pulled...)
+				}
+
+				slices.Sort(stale)
+
+				downServices = slices.Compact(stale)
 				downNoDeps = true
 				recreate = len(downServices) > 0
-				c.LogDebug("Recreating built services", "services", downServices)
+				if recreate {
+					c.LogDebug("Recreating stale services", "services", downServices)
+				}
 			}
 
 			if recreate {
@@ -290,16 +336,7 @@ func newUpCommand() *cli.Command {
 
 			c.LogDebug("Ensure", "resources", stack.All())
 
-			// "missing" and the legacy "policy" are the default, as is anything unknown.
-			pull := client.PullMissing
-			switch cmd.String("pull") {
-			case "always":
-				pull = client.PullAlways
-			case "never":
-				pull = client.PullNever
-			}
-
-			startOptions := append(append([]client.Option{}, runOptions...), client.OptionCreate(), client.OptionPullMode(pull))
+			startOptions := append(append([]client.Option{}, runOptions...), client.OptionCreate())
 			if buildInfo.Mode != client.BuildAuto || buildInfo.PreferredBuilder != "" {
 				startOptions = append(startOptions, client.OptionBuild(buildInfo))
 			}
@@ -388,6 +425,64 @@ func builtServices(p *project.Project, args filterResourcesArgs) []string {
 	slices.Sort(services)
 
 	return services
+}
+
+// pulledServices returns the in-scope services running an image other than the
+// one pull() just ensured for them, sorted.
+func pulledServices(ctx context.Context, p *project.Project, c *client.Client, args filterResourcesArgs, pull client.PullMode, scale map[string]int) ([]string, error) {
+	resources, err := p.Resources(c, project.ResourcesScale(scale))
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := c.Connection()
+	if err != nil {
+		return nil, err
+	}
+
+	services := []string{}
+	for name, res := range filterResources(p, resources, args) {
+		var image *client.Image
+		for _, r := range res {
+			i, ok := r.(*client.Image)
+			if ok {
+				image = i
+				break
+			}
+		}
+
+		if image == nil {
+			continue
+		}
+
+		for _, r := range res {
+			instance, ok := r.(*client.Instance)
+			if !ok {
+				continue
+			}
+
+			// An instance that is not there yet gets the image on creation.
+			current, _, err := conn.GetInstance(ctx, instance.IncusName(), nil)
+			if err != nil {
+				continue
+			}
+
+			if pulledImageChanged(pull, current.Config["volatile.base_image"], image.State().IncusAlias) {
+				services = append(services, name)
+				break
+			}
+		}
+	}
+
+	slices.Sort(services)
+
+	return services, nil
+}
+
+// pulledImageChanged is the recreate policy: only under PullAlways, and only
+// when the pulled alias differs from what the instance runs today.
+func pulledImageChanged(pull client.PullMode, baseImage string, alias *incusApi.ImageAliasesEntry) bool {
+	return pull == client.PullAlways && alias != nil && alias.Target != "" && alias.Target != baseImage
 }
 
 // parseScale parses --scale flags of the form "service=num".

--- a/cmd/incus-compose/up.go
+++ b/cmd/incus-compose/up.go
@@ -224,8 +224,8 @@ func newUpCommand() *cli.Command {
 				pullMode = client.PullNever
 			}
 
-			// The stale set below needs the images pulled first; built ones stay
-			// with builtServices and healthd pulls its own in healthdUp.
+			// The ensure below carries no pull mode, so this is where --pull
+			// lands. Built images stay with builtServices, healthd with healthdUp.
 			err = pull(ctx, p, c, pullArgs{
 				Services:        cmd.Args().Slice(),
 				WithDeps:        !cmd.Bool("no-deps"),
@@ -241,33 +241,14 @@ func newUpCommand() *cli.Command {
 				return err
 			}
 
-			// A rebuilt or re-pulled image only reaches an instance created from it again.
+			// A rebuilt image only reaches an instance created from it again.
 			recreate := cmd.Bool("recreate")
 			downServices, downNoDeps := cmd.Args().Slice(), cmd.Bool("no-deps")
-			if !recreate {
-				stale := []string{}
-				if buildMode == client.BuildForce {
-					stale = builtServices(p, args)
-				}
-
-				if pullMode == client.PullAlways {
-					pulled, err := pulledServices(ctx, p, c, args, pullMode, scale)
-					if err != nil {
-						c.LogError("Comparing the instance images against the pulled ones", "error", err)
-						return errLogged.Wrap(err)
-					}
-
-					stale = append(stale, pulled...)
-				}
-
-				slices.Sort(stale)
-
-				downServices = slices.Compact(stale)
+			if !recreate && buildMode == client.BuildForce {
+				downServices = builtServices(p, args)
 				downNoDeps = true
 				recreate = len(downServices) > 0
-				if recreate {
-					c.LogDebug("Recreating stale services", "services", downServices)
-				}
+				c.LogDebug("Recreating built services", "services", downServices)
 			}
 
 			if recreate {
@@ -350,6 +331,54 @@ func newUpCommand() *cli.Command {
 				return errLogged.Wrap(err)
 			}
 
+			// A pulled image only reaches an instance created from it again, so
+			// the ones the ensure above found on the previous fingerprint are
+			// torn down and made from the new one.
+			if pullMode == client.PullAlways {
+				stale := staleInstances(myResources)
+				if len(stale) > 0 {
+					c.LogDebug("Recreating instances on a replaced image", "instances", stale)
+
+					downStack := client.NewStack(c, client.StackSortDescending(), client.StackWorkers(cmd.Root().Int("workers")))
+					downStack.Add(stale...)
+
+					err = downStack.ForAction(client.ActionStop).Run(ctx, client.ActionStop, client.OptionTimeout(cmd.Duration("timeout")))
+					if err != nil {
+						c.LogError("Stopping instances on a replaced image", "error", err)
+						return errLogged.Wrap(err)
+					}
+
+					err = downStack.ForAction(client.ActionDelete).Run(ctx, client.ActionDelete, client.OptionTimeout(cmd.Duration("timeout")))
+					if err != nil {
+						c.LogError("Deleting instances on a replaced image", "error", err)
+						return errLogged.Wrap(err)
+					}
+
+					// Delete drops them from the client, so Start below runs on
+					// the resources this rebuild registers rather than the dead ones.
+					resources, err = p.Resources(c, project.ResourcesScale(scale))
+					if err != nil {
+						c.LogError("Getting project resources after the teardown", "error", err)
+						return errLogged.Wrap(err)
+					}
+
+					myResources = filterResources(p, resources, args)
+
+					stack = client.NewStack(c, client.StackWorkers(cmd.Root().Int("workers")), client.StackFailFast())
+					stack.AddOrdered(order, myResources)
+
+					// Everything else came through the ensure above; the deleted
+					// instances are what the rebuild handed back unensured.
+					deleted := func(r client.Resource) bool { return !r.IsEnsured() }
+
+					err = stack.ForActionF(client.ActionEnsure, deleted).Run(ctx, client.ActionEnsure, startOptions...)
+					if err != nil {
+						c.LogError("Ensuring the recreated instances", "error", err)
+						return errLogged.Wrap(err)
+					}
+				}
+			}
+
 			// Start
 			if !cmd.Bool("no-start") {
 				startFilter := func(r client.Resource) bool { return r.IsEnsured() }
@@ -427,21 +456,12 @@ func builtServices(p *project.Project, args filterResourcesArgs) []string {
 	return services
 }
 
-// pulledServices returns the in-scope services running an image other than the
-// one pull() just ensured for them, sorted.
-func pulledServices(ctx context.Context, p *project.Project, c *client.Client, args filterResourcesArgs, pull client.PullMode, scale map[string]int) ([]string, error) {
-	resources, err := p.Resources(c, project.ResourcesScale(scale))
-	if err != nil {
-		return nil, err
-	}
+// staleInstances returns the ensured instances running an image other than the
+// one their service holds now, sorted by Incus name.
+func staleInstances(resources map[string][]client.Resource) []client.Resource {
+	stale := []client.Resource{}
 
-	conn, err := c.Connection()
-	if err != nil {
-		return nil, err
-	}
-
-	services := []string{}
-	for name, res := range filterResources(p, resources, args) {
+	for _, res := range resources {
 		var image *client.Image
 		for _, r := range res {
 			i, ok := r.(*client.Image)
@@ -461,28 +481,29 @@ func pulledServices(ctx context.Context, p *project.Project, c *client.Client, a
 				continue
 			}
 
-			// An instance that is not there yet gets the image on creation.
-			current, _, err := conn.GetInstance(ctx, instance.IncusName(), nil)
-			if err != nil {
+			// Nil for one the ensure just created, which already runs the new image.
+			info := instance.State().IncusInstance
+			if info == nil {
 				continue
 			}
 
-			if pulledImageChanged(pull, current.Config["volatile.base_image"], image.State().IncusAlias) {
-				services = append(services, name)
-				break
+			if pulledImageChanged(info.Config["volatile.base_image"], image.State().IncusAlias) {
+				stale = append(stale, instance)
 			}
 		}
 	}
 
-	slices.Sort(services)
+	slices.SortFunc(stale, func(a, b client.Resource) int {
+		return strings.Compare(a.IncusName(), b.IncusName())
+	})
 
-	return services, nil
+	return stale
 }
 
-// pulledImageChanged is the recreate policy: only under PullAlways, and only
-// when the pulled alias differs from what the instance runs today.
-func pulledImageChanged(pull client.PullMode, baseImage string, alias *incusApi.ImageAliasesEntry) bool {
-	return pull == client.PullAlways && alias != nil && alias.Target != "" && alias.Target != baseImage
+// pulledImageChanged reports whether the pulled alias differs from the image
+// the instance runs today.
+func pulledImageChanged(baseImage string, alias *incusApi.ImageAliasesEntry) bool {
+	return alias != nil && alias.Target != "" && alias.Target != baseImage
 }
 
 // parseScale parses --scale flags of the form "service=num".

--- a/cmd/incus-compose/up_test.go
+++ b/cmd/incus-compose/up_test.go
@@ -5,10 +5,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	incusApi "github.com/lxc/incus/v7/shared/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
 
+	"github.com/lxc/incus-compose/client"
 	"github.com/lxc/incus-compose/cmd/incus-compose/version"
 	"github.com/lxc/incus-compose/internal/testlib"
 	"github.com/lxc/incus-compose/project"
@@ -106,6 +108,60 @@ func TestParseScale(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.want, parseScale(tt.values))
+		})
+	}
+}
+
+// TestPulledImageChanged covers the recreate policy up feeds downServices
+// with: gated on PullAlways, and only for an actual change.
+func TestPulledImageChanged(t *testing.T) {
+	t.Parallel()
+
+	imgAlias := func(target string) *incusApi.ImageAliasesEntry {
+		return &incusApi.ImageAliasesEntry{ImageAliasesEntryPut: incusApi.ImageAliasesEntryPut{Target: target}}
+	}
+
+	tests := []struct {
+		name      string
+		pull      client.PullMode
+		baseImage string
+		alias     *incusApi.ImageAliasesEntry
+		want      bool
+	}{
+		{
+			name:      "missing pull never recreates, even with a new fingerprint",
+			pull:      client.PullMissing,
+			baseImage: "old-fingerprint",
+			alias:     imgAlias("new-fingerprint"),
+			want:      false,
+		},
+		{
+			name:      "always pull with an unchanged fingerprint does not recreate",
+			pull:      client.PullAlways,
+			baseImage: "same-fingerprint",
+			alias:     imgAlias("same-fingerprint"),
+			want:      false,
+		},
+		{
+			name:      "always pull with a changed fingerprint recreates",
+			pull:      client.PullAlways,
+			baseImage: "old-fingerprint",
+			alias:     imgAlias("new-fingerprint"),
+			want:      true,
+		},
+		{
+			name:      "always pull with no ensured alias never recreates",
+			pull:      client.PullAlways,
+			baseImage: "old-fingerprint",
+			alias:     nil,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, pulledImageChanged(tt.pull, tt.baseImage, tt.alias))
 		})
 	}
 }

--- a/cmd/incus-compose/up_test.go
+++ b/cmd/incus-compose/up_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
 
-	"github.com/lxc/incus-compose/client"
 	"github.com/lxc/incus-compose/cmd/incus-compose/version"
 	"github.com/lxc/incus-compose/internal/testlib"
 	"github.com/lxc/incus-compose/project"
@@ -112,8 +111,8 @@ func TestParseScale(t *testing.T) {
 	}
 }
 
-// TestPulledImageChanged covers the recreate policy up feeds downServices
-// with: gated on PullAlways, and only for an actual change.
+// TestPulledImageChanged covers what up feeds the recreate teardown: an
+// unensured image never recreates, a changed fingerprint does.
 func TestPulledImageChanged(t *testing.T) {
 	t.Parallel()
 
@@ -123,37 +122,32 @@ func TestPulledImageChanged(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		pull      client.PullMode
 		baseImage string
 		alias     *incusApi.ImageAliasesEntry
 		want      bool
 	}{
 		{
-			name:      "missing pull never recreates, even with a new fingerprint",
-			pull:      client.PullMissing,
-			baseImage: "old-fingerprint",
-			alias:     imgAlias("new-fingerprint"),
-			want:      false,
-		},
-		{
-			name:      "always pull with an unchanged fingerprint does not recreate",
-			pull:      client.PullAlways,
+			name:      "an unchanged fingerprint does not recreate",
 			baseImage: "same-fingerprint",
 			alias:     imgAlias("same-fingerprint"),
 			want:      false,
 		},
 		{
-			name:      "always pull with a changed fingerprint recreates",
-			pull:      client.PullAlways,
+			name:      "a changed fingerprint recreates",
 			baseImage: "old-fingerprint",
 			alias:     imgAlias("new-fingerprint"),
 			want:      true,
 		},
 		{
-			name:      "always pull with no ensured alias never recreates",
-			pull:      client.PullAlways,
+			name:      "no ensured alias never recreates",
 			baseImage: "old-fingerprint",
 			alias:     nil,
+			want:      false,
+		},
+		{
+			name:      "an empty alias target never recreates",
+			baseImage: "old-fingerprint",
+			alias:     imgAlias(""),
 			want:      false,
 		},
 	}
@@ -161,7 +155,7 @@ func TestPulledImageChanged(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, pulledImageChanged(tt.pull, tt.baseImage, tt.alias))
+			assert.Equal(t, tt.want, pulledImageChanged(tt.baseImage, tt.alias))
 		})
 	}
 }


### PR DESCRIPTION
up --build already recreates a service when the build produces a new image (cmd/incus-compose/up.go's builtServices()), but --pull always  doesn't have the equivalent: a re-pulled image reaches the image store but never reaches a running instance until something also passes  --recreate by hand. ensured()'s own comment on this file already states the premise this PR completes: "Keys only: a changed value still  needs --recreate."  

 This adds the pull half of that mechanism. Instance.ensure(), in its existing-instance branch, now asks whether the already-ensured Image  resource's alias fingerprint differs from the instance's volatile.base_image, gated strictly on options.Pull == PullAlways. Ensure() already  has a Stop+Delete path for the scale-down (deleteMarked) case; it now also recreates - after Delete(), if the image changed, it calls itself  again, which lands in the ordinary not-found -> create() path with no new creation logic. 

 No reordering of up.go was needed: Stack.Run() executes priority batches strictly in sequence (PriorityImage = 1<<10, PriorityInstance =  1<<13), so by the time any instance's Ensure() runs, every image it depends on - including a PullAlways refresh - has already finished, in  the same stack run. That ordering already existed; this PR just reads the result of it. 

 recreate is also gated on options.Create. Right now that's redundant in practice - up.go, pull.go and build_linux.go are the only three call  sites that ever set OptionPullMode, and all three already set OptionCreate too, so up is the only command that ensures instances with a pull  mode at all, and this stays confined to --pull always. But that confinement was only a property of the callers, not of ensure() itself, so  the guard makes it a local invariant instead of one three call sites have to keep upholding by convention. 

 Added TestPulledImageChanged, a table test on the extracted decision function (pulledImageChanged), matching TestResolveEntrypoint's existing pattern of pulling pure logic out of Instance and testing it standalone. It explicitly covers the case that must not change: PullMissing  (the default up) never recreates, even when the fingerprints differ. 

What I verified: INCUS_COMPOSE_TEST_LOCAL=1 go test ./... passes clean, gofmt -l . is silent, no non-ASCII, no new if err := ...; err != nil  one-liner. Non-test diff is 61 lines. 

What I did not verify: this was never run against a live Incus instance, single- or multi-node - I don't have a safe place to do that outside my own production cluster right now. Everything about the runtime path (r.client.Resource() returning the same already-ensured image object, the recursive Ensure() landing in create(), volatile.base_image holding the fingerprint ensured() already reads two lines above) is reasoned from source, not observed live. Happy to adjust based on CI or a review that catches something the source reading missed. 

Fixes #118. 