### PR TITLE
fix(client): drop a cached image built for another architecture

### DIFF
--- a/client/resource_image.go
+++ b/client/resource_image.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -701,6 +702,10 @@ func (r *Image) create(ctx context.Context, args Options) error {
 func (r *Image) materialize(ctx context.Context, args Options) (*incusApi.ImageAliasesEntry, error) {
 	cacheAlias, _, err := r.cache.incus.GetImageAlias(ctx, r.cache.incusProject, r.incusName, nil)
 	if err == nil {
+		err = r.dropIfWrongArch(ctx, cacheAlias)
+	}
+
+	if err == nil {
 		// An entry cached before the split still concatenates entrypoint and
 		// command, so reading the config again upgrades it where it lies.
 		err = r.ociStoreConfig(ctx, r.cache.incus, r.cache.incusProject, cacheAlias.Target, nil)
@@ -733,6 +738,42 @@ func (r *Image) materialize(ctx context.Context, args Options) (*incusApi.ImageA
 	}
 
 	return cacheAlias, nil
+}
+
+// dropIfWrongArch clears err back to a cache miss when alias resolves to an
+// image this server cannot run, deleting it so the fallthrough pull replaces
+// it. The cache project is shared cluster-wide, not per-node, so a member of
+// another architecture may have materialized the alias first; without this,
+// every other-architecture member reusing the same alias silently inherits
+// that image forever.
+func (r *Image) dropIfWrongArch(ctx context.Context, alias *incusApi.ImageAliasesEntry) error {
+	img, _, err := r.cache.incus.GetImage(ctx, r.cache.incusProject, alias.Target, nil)
+	if err != nil {
+		return err
+	}
+
+	conn, err := r.client.Connection()
+	if err != nil {
+		return err
+	}
+
+	server, _, err := conn.GetServer(ctx)
+	if err != nil {
+		return err
+	}
+
+	if slices.Contains(server.Environment.Architectures, img.Architecture) {
+		return nil
+	}
+
+	r.client.LogWarn("Dropping cached image built for another architecture", "resource", r,
+		"cached", img.Architecture, "server", server.Environment.Architectures)
+
+	if err := deleteImage(ctx, r.cache.incus, r.cache.incusProject, alias.Target); err != nil {
+		return ErrCreate.WithText("removing wrong-architecture cached image").Wrap(err)
+	}
+
+	return ErrNotFound.WithText("cached image architecture mismatch")
 }
 
 // createDirect copies the source straight into the project, used when no cache

--- a/client/resource_image_test.go
+++ b/client/resource_image_test.go
@@ -1,8 +1,12 @@
 package client
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -686,6 +690,89 @@ func TestImageEnsure_ProjectCopySurvivesCacheDeletion(t *testing.T) {
 	// A refill would mean it went looking past its own project.
 	_, _, err = img.cache.incus.GetImageAlias(ctx, img.cache.incusProject, img.incusName, nil)
 	require.Error(t, err, "ensure repopulated the cache instead of using the project copy")
+}
+
+// emptyTar returns a valid, empty tar stream, enough for incusd to accept a
+// manually-crafted image whose content is never actually unpacked into a
+// running instance.
+func emptyTar(t *testing.T) io.Reader {
+	t.Helper()
+
+	var buf bytes.Buffer
+	require.NoError(t, tar.NewWriter(&buf).Close())
+
+	return &buf
+}
+
+// TestImageEnsure_DropsCachedWrongArch covers the cache project
+// (DefaultCacheProject, or here a client-scoped stand-in) being shared
+// cluster-wide, not per node: a member of another architecture may already
+// have materialized this alias. Ensure must notice a cached image built for
+// an architecture this server does not run, drop it, and pull one that
+// actually fits, rather than handing the mismatched image to the project
+// unexamined.
+func TestImageEnsure_DropsCachedWrongArch(t *testing.T) {
+	skipLocal(t)
+	ctx := t.Context()
+
+	cache := newRandomTestClient(t, "image-wrong-arch-cache-")
+	c := newRandomTestClient(t, "image-wrong-arch-")
+
+	name := "docker.io/library/alpine:3.21"
+	r, err := c.Resource(KindImage, name, &ImageConfig{CacheClient: cache})
+	require.NoError(t, err)
+
+	img, ok := r.(*Image)
+	require.True(t, ok)
+
+	conn, err := c.Connection()
+	require.NoError(t, err)
+	server, _, err := conn.GetServer(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, server.Environment.Architectures)
+
+	// A name no real host reports, so the planted entry is unambiguously wrong.
+	wrongArch := "riscv64"
+	if slices.Contains(server.Environment.Architectures, wrongArch) {
+		wrongArch = "s390x"
+	}
+
+	meta, err := buildMetadataTar(name, wrongArch, nil)
+	require.NoError(t, err)
+
+	op, err := cache.incus.CreateImage(ctx, cache.incusProject, incusApi.ImagesPost{
+		Aliases: []incusApi.ImageAlias{{Name: name}},
+	}, &iclient.ImageCreateArgs{
+		MetaFile:   meta,
+		MetaName:   "metadata.tar",
+		RootfsFile: emptyTar(t),
+		RootfsName: "rootfs.tar",
+	})
+	require.NoError(t, err)
+	_, err = iclient.WaitOperation(ctx, op)
+	require.NoError(t, err)
+
+	poisoned, _, err := cache.incus.GetImageAlias(ctx, cache.incusProject, name, nil)
+	require.NoError(t, err)
+
+	poisonedImg, _, err := cache.incus.GetImage(ctx, cache.incusProject, poisoned.Target, nil)
+	require.NoError(t, err)
+	require.Equal(t, wrongArch, poisonedImg.Architecture,
+		"test setup: the planted cache entry must actually be wrong-arch")
+
+	// Ensure must not hand the wrong-architecture cached image to the
+	// project: it has to notice, drop it, and pull one this server can run.
+	require.NoError(t, RunAction(ctx, r, ActionEnsure, OptionCreate()))
+	require.True(t, r.IsEnsured())
+
+	got, _, err := conn.GetImage(ctx, c.incusProject, img.State().IncusAlias.Target, nil)
+	require.NoError(t, err)
+	require.Contains(t, server.Environment.Architectures, got.Architecture)
+
+	// The wrong-architecture blob itself must be gone, not just unaliased, or
+	// the next server of that same architecture inherits it right back.
+	_, _, err = cache.incus.GetImage(ctx, cache.incusProject, poisoned.Target, nil)
+	require.Error(t, err, "the wrong-architecture cached image must be deleted")
 }
 
 func TestImagePullNever_NoCacheStoreMiss(t *testing.T) {


### PR DESCRIPTION
`materialize()` treated any alias already present in the cache project as usable, with no check against the architecture(s) this server actually runs. The cache project (`DefaultCacheProject`, or a caller's `CacheClient`) is shared cluster-wide rather than per node, so on a mixed-architecture cluster whichever member materializes an alias first fixes its architecture for every other member that reuses the same alias - the wrong image gets silently copied into the project, and Incus then schedules the instance onto whichever member's architecture happens to match it, not necessarily the one the operator ran incus-compose on.

Now `materialize()` reads the cached image's own Architecture and checks it against the server's Environment.Architectures before trusting a hit; a mismatch is dropped and treated as a cache miss so the normal pull path replaces it with one this server can run.

Scoped to the pull path only (simplestreams and OCI both go through `materialize()`); the locally-built image cache hit in `ensureBuild()` has the same shape of bug but is a separate, unreported issue.