### PR TITLE
feat(client,project): assign Incus profiles via x-incus-compose.profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ for correct semver ordering. Headings below preserve each release's announced fo
 
 ### Added
 
+- `services.{name}.x-incus-compose.profiles`: set the instance's full Incus
+  profile list on create, verbatim - same semantics as `incus launch
+  --profile`, so a list that omits `default` leaves the instance without it.
+  Until now nothing in compose could express profile *membership*: `x-incus`
+  merges into the instance's config map, and `profiles` is a field on the
+  instance struct, not a config key. (by @alien43)
+
 - `run SERVICE [COMMAND]` starts a one-off instance from a service and exits
   with the command's own status, as `docker compose run` does. Incus reports no
   exit status for an instance that stopped, so the instance runs a helper that

--- a/client/resource_instance.go
+++ b/client/resource_instance.go
@@ -85,6 +85,13 @@ type InstanceConfig struct {
 	// ExtraDevices contains additional raw device configurations.
 	ExtraDevices map[string]map[string]string
 
+	// Profiles is the instance's full Incus profile list, from
+	// x-incus-compose.profiles. Same semantics as `incus launch --profile`:
+	// set verbatim, not merged with the implicit "default" profile - a list
+	// that omits "default" means the instance won't carry it. Nil leaves
+	// Incus's own default (the "default" profile) untouched.
+	Profiles []string
+
 	// NoRootDevice takes the root disk from the instance's profile instead.
 	NoRootDevice bool
 
@@ -668,6 +675,7 @@ func (r *Instance) create(ctx context.Context, opts ...Option) error {
 			Description: fmt.Sprintf(r.client.Config().DescriptionFormat, r.Name()),
 			Config:      config,
 			Devices:     devices,
+			Profiles:    r.Config.Profiles,
 		},
 	}
 

--- a/project/instance.go
+++ b/project/instance.go
@@ -112,6 +112,11 @@ func serviceToInstance(c *client.Client, p *types.Project, serviceName string, o
 		devices = append(devices, oneOffDevice(oneOff))
 	}
 
+	profiles, err := serviceExtraProfiles(service)
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+
 	secrets, err := instanceSecrets(p, service)
 	if err != nil {
 		errs = errors.Join(errs, err)
@@ -140,6 +145,7 @@ func serviceToInstance(c *client.Client, p *types.Project, serviceName string, o
 		Resources:     slices.Clone(resources),
 		Extensions:    config,
 		Devices:       devices,
+		Profiles:      profiles,
 		Files:         files,
 		Dependencies:  instanceDependencyWaits(p, service, options),
 		Entrypoint:    service.Entrypoint,
@@ -1315,6 +1321,34 @@ func serviceExtraDevices(service types.ServiceConfig) ([]client.InstanceDevice, 
 	}
 
 	return devices, nil
+}
+
+// serviceExtraProfiles extracts the x-incus-compose.profiles list from a
+// compose service. It becomes the instance's full Incus profile list - same
+// semantics as `incus launch --profile`, so a list that omits "default"
+// leaves the instance without it.
+func serviceExtraProfiles(service types.ServiceConfig) ([]string, error) {
+	var raw map[string]any
+	ok, err := service.Extensions.Get("x-incus-compose", &raw)
+	if !ok || err != nil {
+		return nil, nil //nolint:nilerr // missing/malformed extension means no extra profiles
+	}
+
+	profilesRaw, ok := raw["profiles"].([]any)
+	if !ok || len(profilesRaw) == 0 {
+		return nil, nil
+	}
+
+	profiles := make([]string, 0, len(profilesRaw))
+	for _, p := range profilesRaw {
+		name, ok := p.(string)
+		if !ok {
+			return nil, fmt.Errorf("x-incus-compose.profiles: entry %v must be a string", p)
+		}
+		profiles = append(profiles, name)
+	}
+
+	return profiles, nil
 }
 
 // checkEntrypoint rejects a service whose entrypoint and command are both

--- a/project/instance_test.go
+++ b/project/instance_test.go
@@ -778,6 +778,51 @@ func TestServiceExtraDevices(t *testing.T) {
 	})
 }
 
+func TestServiceExtraProfiles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("profiles list", func(t *testing.T) {
+		t.Parallel()
+		service := types.ServiceConfig{Name: "web", Extensions: types.Extensions{
+			"x-incus-compose": map[string]any{
+				"profiles": []any{"lan", "gpu"},
+			},
+		}}
+
+		profiles, err := serviceExtraProfiles(service)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"lan", "gpu"}, profiles)
+	})
+
+	t.Run("non-string entry errors", func(t *testing.T) {
+		t.Parallel()
+		service := types.ServiceConfig{Name: "web", Extensions: types.Extensions{
+			"x-incus-compose": map[string]any{
+				"profiles": []any{"lan", 5},
+			},
+		}}
+		_, err := serviceExtraProfiles(service)
+		require.Error(t, err)
+	})
+
+	t.Run("no extension", func(t *testing.T) {
+		t.Parallel()
+		profiles, err := serviceExtraProfiles(types.ServiceConfig{Name: "web"})
+		require.NoError(t, err)
+		assert.Nil(t, profiles)
+	})
+
+	t.Run("empty list is nil", func(t *testing.T) {
+		t.Parallel()
+		service := types.ServiceConfig{Name: "web", Extensions: types.Extensions{
+			"x-incus-compose": map[string]any{"profiles": []any{}},
+		}}
+		profiles, err := serviceExtraProfiles(service)
+		require.NoError(t, err)
+		assert.Nil(t, profiles)
+	})
+}
+
 func TestInstanceImage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`Instance.create()` built `InstancesPost` without ever setting `Profiles`, and `client.InstanceConfig` had no field for one - so an instance's profile membership had no compose expression and did not survive a recreate. `x-incus` doesn't reach it either: it merges into the instance's config map, and profiles is a field on the instance struct, not a config key.

`services.{name}.x-incus-compose.profiles` sets the instance's full profile list on create, verbatim - same semantics as `incus launch --profile`, so a list that omits "default" leaves the instance without it.