### PR TITLE
fix(client): skip service DNS records on non-bridge networks

### DIFF
--- a/client/resource_network.go
+++ b/client/resource_network.go
@@ -393,6 +393,7 @@ func (r *Network) Delete(ctx context.Context, opts ...Option) error {
 
 // updateDNSAliases reads raw.dnsmasq from Incus, replaces records for
 // ownedServices with newIPs (preserving all other records), and writes back.
+// Non-bridge networks are skipped: raw.dnsmasq is a bridge-only option.
 // Setting raw.dnsmasq disables AppArmor for the dnsmasq process (not containers).
 // The update is idempotent: if the resulting config is unchanged, dnsmasq is not restarted.
 func (r *Network) updateDNSAliases(ctx context.Context, ownedServices []string, newIPs map[string][]string) error {
@@ -408,6 +409,11 @@ func (r *Network) updateDNSAliases(ctx context.Context, ownedServices []string, 
 	net, etag, err := conn.GetNetwork(ctx, incusApi.ProjectDefaultName, r.incusName)
 	if err != nil {
 		return fmt.Errorf("reading network %q: %w", r.Name(), err)
+	}
+
+	if net.Type != "bridge" {
+		r.client.LogDebug("skipping service DNS records: network is not a bridge", "network", r.Name(), "type", net.Type)
+		return nil
 	}
 
 	cAddresses, cCnames, cExtra := DNSmasqParse(net.Config["raw.dnsmasq"])


### PR DESCRIPTION
Fixes #185

`raw.dnsmasq` is a bridge-only option, but the DNSWatcher wrote it to every
network of the project, so with an external OVN network every
`up`/`start`/`stop` failed mid-phase and the stack could never converge
(details in #185).

`updateDNSAliases` now returns early on networks whose type is not `bridge`,
with a debug log. On OVN networks instance names already resolve through the
network's own DNS, so the only loss is the service-name round-robin, which
`raw.dnsmasq` cannot provide there anyway.

Tested on a 3-node Incus 7.3 cluster (OVN + Linstor):

- external OVN network: unpatched `up -d` exits 1 with
  `Invalid option ... "raw.dnsmasq"`; patched it converges (exit 0,
  idempotent on re-run) and `--debug` shows
  `skipping service DNS records: network is not a bridge ... type=ovn`.
- external bridge network: service records are still written on `up`
  and removed on `down`.
