### PR TITLE
fix: let the auto-volume check see x-incus-compose.devices

### DIFF
--- a/client/resource_instance_prefetch_test.go
+++ b/client/resource_instance_prefetch_test.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// devicePath() decides whether a path an image declares as a VOLUME is already
+// covered by a device, and reads Config.Disk.Path / Config.Tmpfs.Path to do it.
+// An x-incus-compose device that leaves those empty is invisible to the check.
+func TestDevicePathSeesExtraDevices(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		device InstanceDevice
+		at     string
+		want   string
+	}{
+		{
+			name: "disk from x-incus-compose.devices covers its path",
+			device: InstanceDevice{
+				Name: "app-config",
+				Config: InstanceDeviceConfig{
+					DeviceType: InstanceDeviceTypeDisk,
+					Disk:       InstanceDeviceDiskConfig{Path: "/config"},
+					Extensions: map[string]string{
+						"type": "disk", "pool": "default",
+						"source": "web-config", "path": "/config",
+					},
+				},
+			},
+			at:   "/config",
+			want: "/config",
+		},
+		{
+			name: "a child of a covered path is also covered",
+			device: InstanceDevice{
+				Name: "app-data",
+				Config: InstanceDeviceConfig{
+					DeviceType: InstanceDeviceTypeDisk,
+					Disk:       InstanceDeviceDiskConfig{Path: "/opt"},
+					Extensions: map[string]string{"type": "disk", "path": "/opt"},
+				},
+			},
+			at:   "/opt/data",
+			want: "/opt",
+		},
+		{
+			name: "tmpfs from x-incus-compose.devices covers its path",
+			device: InstanceDevice{
+				Name: "scratch",
+				Config: InstanceDeviceConfig{
+					DeviceType: InstanceDeviceTypeTmpfs,
+					Tmpfs:      InstanceDeviceTmpfsConfig{Path: "/var/lib/influxdb2"},
+					Extensions: map[string]string{"type": "tmpfs", "path": "/var/lib/influxdb2"},
+				},
+			},
+			at:   "/var/lib/influxdb2",
+			want: "/var/lib/influxdb2",
+		},
+		{
+			name: "an unrelated path is still uncovered",
+			device: InstanceDevice{
+				Name: "app-config",
+				Config: InstanceDeviceConfig{
+					DeviceType: InstanceDeviceTypeDisk,
+					Disk:       InstanceDeviceDiskConfig{Path: "/config"},
+					Extensions: map[string]string{"type": "disk", "path": "/config"},
+				},
+			},
+			at:   "/data",
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := &Instance{Config: InstanceConfig{Devices: []InstanceDevice{tc.device}}}
+			assert.Equal(t, tc.want, r.devicePath(tc.at))
+		})
+	}
+}

--- a/project/instance.go
+++ b/project/instance.go
@@ -1333,13 +1333,31 @@ func serviceExtraDevices(service types.ServiceConfig) ([]client.InstanceDevice, 
 			return nil, fmt.Errorf("x-incus-compose.devices: device %q is missing 'type'", name)
 		}
 
-		devices = append(devices, client.InstanceDevice{
-			Name: name,
-			Config: client.InstanceDeviceConfig{
-				DeviceType: ext["type"],
-				Extensions: ext,
-			},
-		})
+		cfg := client.InstanceDeviceConfig{
+			DeviceType: ext["type"],
+			Extensions: ext,
+		}
+
+		// Mirror the mount point into the typed config as well as Extensions.
+		// devicePath() -- which decides whether a path an image declares as a
+		// VOLUME is already covered by a device -- reads Config.Disk.Path and
+		// Config.Tmpfs.Path, never Extensions. Leaving them empty made every
+		// x-incus-compose disk invisible to that check, so prefetchVolumes()
+		// created an auto-volume for an already-covered path and Incus then
+		// rejected the instance with "More than one disk device uses the same
+		// path" -- after `up --recreate` had already deleted the old instance.
+		//
+		// Rendering is unaffected: toDiskDevice()/toTmpfsDevice() apply
+		// maps.Copy(device, Extensions) last, so Extensions still win with the
+		// identical value.
+		switch ext["type"] {
+		case client.InstanceDeviceTypeDisk:
+			cfg.Disk.Path = ext["path"]
+		case client.InstanceDeviceTypeTmpfs:
+			cfg.Tmpfs.Path = ext["path"]
+		}
+
+		devices = append(devices, client.InstanceDevice{Name: name, Config: cfg})
 	}
 
 	return devices, nil

--- a/project/instance_test.go
+++ b/project/instance_test.go
@@ -834,6 +834,55 @@ func TestServiceExtraDevices(t *testing.T) {
 		assert.Equal(t, map[string]string{"type": "gpu", "gputype": "physical"}, cfg)
 	})
 
+	// prefetchVolumes() skips a path only when devicePath() reports a device
+	// covering it, and devicePath() reads Config.Disk.Path / Config.Tmpfs.Path --
+	// never Extensions. Leaving them unset makes the device invisible to that
+	// check, so an auto-volume is created for an already-covered path.
+	t.Run("typed mount point is populated so the auto-volume check can see it", func(t *testing.T) {
+		t.Parallel()
+		service := types.ServiceConfig{Name: "web", Extensions: types.Extensions{
+			"x-incus-compose": map[string]any{
+				"devices": map[string]any{
+					"app-config": map[string]any{
+						"type": "disk", "pool": "default",
+						"source": "web-config", "path": "/config",
+					},
+				},
+			},
+		}}
+
+		devices, err := serviceExtraDevices(service)
+		require.NoError(t, err)
+		require.Len(t, devices, 1)
+		assert.Equal(t, "/config", devices[0].Config.Disk.Path,
+			"Disk.Path must be set or devicePath() cannot see this mount")
+
+		// And rendering is unchanged: Extensions are copied last, so they still
+		// win with the identical value.
+		_, cfg, derr := devices[0].ToIncusDevice()
+		require.Nil(t, derr)
+		assert.Equal(t, map[string]string{
+			"type": "disk", "pool": "default",
+			"source": "web-config", "path": "/config",
+		}, cfg)
+	})
+
+	t.Run("tmpfs mount point is populated too", func(t *testing.T) {
+		t.Parallel()
+		service := types.ServiceConfig{Name: "influxdb", Extensions: types.Extensions{
+			"x-incus-compose": map[string]any{
+				"devices": map[string]any{
+					"scratch": map[string]any{"type": "tmpfs", "path": "/var/lib/influxdb2"},
+				},
+			},
+		}}
+
+		devices, err := serviceExtraDevices(service)
+		require.NoError(t, err)
+		require.Len(t, devices, 1)
+		assert.Equal(t, "/var/lib/influxdb2", devices[0].Config.Tmpfs.Path)
+	})
+
 	t.Run("missing type errors", func(t *testing.T) {
 		t.Parallel()
 		service := types.ServiceConfig{Name: "web", Extensions: types.Extensions{


### PR DESCRIPTION
`prefetchVolumes()` gives every image-declared `VOLUME` its own storage volume unless `devicePath()` reports a device already covering that path.

`devicePath()` reads `Config.Disk.Path` / `Config.Tmpfs.Path`, but `serviceExtraDevices()` set only `DeviceType` and `Extensions` — so `coversPath("")` was false and every `x-incus-compose.devices` disk was invisible to the check. An auto-volume then gets created for an already-covered path and Incus rejects the instance:

    Device validation failed for "z-app-config": More than one disk device uses
    the same path "/config"

`up --recreate` only reaches that point after it has stopped and deleted the old instance, so the stack is left with nothing running.

`devicePath()`'s fallback loop over `Config.ExtraDevices` cannot help — that field is never assigned outside tests.

Fix: populate the typed mount point alongside `Extensions`. Rendering is unchanged, since `toDiskDevice()` and `toTmpfsDevice()` both end with `maps.Copy(device, Extensions)` — `Extensions` still win with the identical value.

Tests: a regression test in `project/`, verified to fail without the fix, and a `devicePath()` table test in `client/`.