### PR TITLE
fix: `down` must not report success when a delete failed

### DIFF
--- a/cmd/incus-compose/down.go
+++ b/cmd/incus-compose/down.go
@@ -27,6 +27,13 @@ type downArgs struct {
 	Writer     io.Writer
 	Reverse    bool
 	NoHealthd  bool
+
+	// ReportErrors makes down return a teardown failure instead of only logging
+	// it. `up --recreate` sets it, because it calls down() before the ensure
+	// phase and a delete that silently failed leaves that ensure accepting the
+	// surviving instance — a recreate that exits 0 and changes nothing. A plain
+	// `down` stays best-effort.
+	ReportErrors bool
 }
 
 // down stops and removes the project's resources.
@@ -144,6 +151,13 @@ func down(ctx context.Context, p *project.Project, c *client.Client, args downAr
 			c.LogError("Deleting the project", "error", err)
 			return errLogged.Wrap(err)
 		}
+	}
+
+	// Reported only now, so the one-offs and the project above are still cleaned
+	// up. The kinds meaning "already gone" were filtered per resource by the
+	// IgnoreError hooks at the top, so anything left here is a real failure.
+	if errDel != nil && args.ReportErrors {
+		return errLogged.Wrap(errDel)
 	}
 
 	return nil

--- a/cmd/incus-compose/up.go
+++ b/cmd/incus-compose/up.go
@@ -273,6 +273,10 @@ func newUpCommand() *cli.Command {
 					Writer:     cmd.Root().Writer,
 					Reverse:    true,
 					NoHealthd:  !usesHealthd,
+
+					// A delete that failed here must not look like success: the
+					// ensure below would accept the surviving instance and exit 0.
+					ReportErrors: true,
 				})
 				if err != nil {
 					return err


### PR DESCRIPTION
`down()` logged delete failures as warnings and returned `nil`. `up --recreate` calls it before the ensure phase, which then finds the instance still present, takes its "already there" branch and reports success — a recreate that exits 0 and changes nothing. Seen in production: an instance ran its previous image for four nights while nightly recreates reported success. Reproduce with `incus config set <inst> security.protection.delete=true`.

Returning `errDel` unconditionally would break `down` on a partially-created stack, since `Delete()` reports `ErrNotEnsured` for a resource that was never created — that is why it was swallowed. So classify instead: `client.IsAlreadyAbsent`, defined beside the sentinels it names, and `down()` propagates anything else.

It requires *every* leaf of an `errors.Join` tree to be tolerable; `errors.Is` is true when merely one is, which would excuse a real failure joined with a benign one.

`errStop` stays a warning: a failed stop followed by a successful delete still reached the desired state.