### PR TITLE
fix: honour `internal: true` without a static address

### DIFF
--- a/project/instance.go
+++ b/project/instance.go
@@ -496,6 +496,7 @@ func instanceNetworkDevices(c *client.Client, p *types.Project, service types.Se
 		extensions := map[string]string{}
 		userExtensions := map[string]string{}
 		noGateway := false
+		internal := false
 		if sNet != nil && sNet.Extensions != nil {
 			userExtensions = xIncusExtensions(sNet.Extensions)
 
@@ -507,6 +508,7 @@ func instanceNetworkDevices(c *client.Client, p *types.Project, service types.Se
 			if err == nil && ext.Internal {
 				gateway4 = "none"
 				gateway6 = "none"
+				internal = true
 			}
 
 			noGateway = ext.Gateway != nil && !*ext.Gateway
@@ -533,7 +535,13 @@ func instanceNetworkDevices(c *client.Client, p *types.Project, service types.Se
 			continue
 		}
 
-		if ((ipv4Address != "" && gateway4 == "none") || (ipv6Address != "" && gateway6 == "none")) &&
+		// `internal: true` is a request for no gateway, so it must be written with
+		// or without a static address — otherwise the "none" computed above is
+		// discarded and the instance silently keeps a default route.
+		writeGateway4 := ipv4Address != "" || internal
+		writeGateway6 := ipv6Address != "" || internal
+
+		if ((writeGateway4 && gateway4 == "none") || (writeGateway6 && gateway6 == "none")) &&
 			!c.Global().HasExtension(shared.Incus73Extension) {
 			c.LogWarn(
 				"For `gateway=none` on a network you need at least incus 7.3 or 7.0.2 LTS",
@@ -545,11 +553,17 @@ func instanceNetworkDevices(c *client.Client, p *types.Project, service types.Se
 
 		if ipv4Address != "" {
 			extensions["ipv4.address"] = ipv4Address
+		}
+
+		if writeGateway4 {
 			extensions["ipv4.gateway"] = gateway4
 		}
 
 		if ipv6Address != "" {
 			extensions["ipv6.address"] = ipv6Address
+		}
+
+		if writeGateway6 {
 			extensions["ipv6.gateway"] = gateway6
 		}
 

--- a/project/instance_test.go
+++ b/project/instance_test.go
@@ -1137,6 +1137,38 @@ func TestInstanceNetworkDevices(t *testing.T) {
 		assert.Equal(t, "none", devices[0].Config.Extensions["ipv4.gateway"])
 	})
 
+	t.Run("internal network gets gateway none without a static address", func(t *testing.T) {
+		t.Parallel()
+		testlib.SkipNoExtension(t, shared.Incus73Extension, "For `gateway=none` on a network you need at least incus 7.3 or 7.0.2 LTS")
+
+		p := &types.Project{Networks: types.Networks{"isolated": {}}}
+		service := types.ServiceConfig{Name: "web", Networks: map[string]*types.ServiceNetworkConfig{
+			"isolated": {Extensions: types.Extensions{"x-incus-compose": map[string]any{"internal": true}}},
+		}}
+
+		devices, _, err := instanceNetworkDevices(c, p, service, "")
+		require.NoError(t, err)
+		require.Len(t, devices, 1)
+		assert.Equal(t, "none", devices[0].Config.Extensions["ipv4.gateway"])
+		assert.Equal(t, "none", devices[0].Config.Extensions["ipv6.gateway"])
+		assert.NotContains(t, devices[0].Config.Extensions, "ipv4.address")
+	})
+
+	t.Run("an ordinary address-less network still gets no gateway key", func(t *testing.T) {
+		t.Parallel()
+
+		p := &types.Project{Networks: types.Networks{"frontend": {}}}
+		service := types.ServiceConfig{Name: "web", Networks: map[string]*types.ServiceNetworkConfig{
+			"frontend": {},
+		}}
+
+		devices, _, err := instanceNetworkDevices(c, p, service, "")
+		require.NoError(t, err)
+		require.Len(t, devices, 1)
+		assert.NotContains(t, devices[0].Config.Extensions, "ipv4.gateway")
+		assert.NotContains(t, devices[0].Config.Extensions, "ipv6.gateway")
+	})
+
 	t.Run("an external network is named by its compose name", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
`internal: true` computes `gateway4/gateway6 = "none"`, but the write only happened inside `if ipv4Address != ""`. A service on an internal network with no static address therefore got no `ipv4.gateway` override at all — a normal default route and full outbound egress, which is the opposite of what was asked for.

Gate the gateway write on the request rather than on the address, and widen the Incus 7.3 version check to match so the newly written case is still covered.

`gateway4` defaults to `"none"`, so writing it unconditionally would put `ipv4.gateway=none` on every address-less network — a much broader change than this bug. Only an explicit `internal: true` triggers it; a test asserts an ordinary address-less network still gets no gateway key.