### PR TITLE
fix(enricher): find a NIC by what Incus records about it, not by its device key

### DIFF
--- a/ievent/enricher/state.go
+++ b/ievent/enricher/state.go
@@ -277,10 +277,18 @@ func (s *state) interfaces(
 
 	networks = map[string]*iutil.Network{}
 
-	for device, iface := range instanceState.Network {
+	// The state keys an interface by its name in the guest, which is the
+	// device key only by default. A profile may call the device anything -
+	// "eth-1", or the network's own name - while the guest still sees eth0, so
+	// the device is found by what Incus records about it rather than by name.
+	byHwaddr, byName := nicIndex(inst, devices)
+
+	for ifname, iface := range instanceState.Network {
 		if iface.Type == "loopback" {
 			continue
 		}
+
+		device := nicDevice(ifname, iface, byHwaddr, byName)
 
 		// A NIC on an unmanaged host bridge carries parent instead of network,
 		// with no network key at all - both are valid device shapes.
@@ -317,6 +325,69 @@ func (s *state) interfaces(
 	})
 
 	return found, networks, "", true
+}
+
+// nicIndex maps what the state reports about an interface - its hardware
+// address, and its name in the guest - back to the key its device has in the
+// configuration. Incus records both on the instance as volatile.<device>.hwaddr
+// and volatile.<device>.name once the NIC is up; a device may also pin either
+// itself. The key is the last resort, and the only one when nothing is
+// recorded, which is what a device that has never been started looks like.
+func nicIndex(
+	inst *incusapi.Instance,
+	devices map[string]map[string]string,
+) (byHwaddr, byName map[string]string) {
+	config := inst.ExpandedConfig
+	if len(config) == 0 {
+		config = inst.Config
+	}
+
+	byHwaddr = map[string]string{}
+	byName = map[string]string{}
+
+	for key, device := range devices {
+		if t := device["type"]; t != "" && t != "nic" {
+			continue
+		}
+
+		for _, hwaddr := range []string{config["volatile."+key+".hwaddr"], device["hwaddr"]} {
+			if hwaddr != "" {
+				byHwaddr[strings.ToLower(hwaddr)] = key
+			}
+		}
+
+		name := device["name"]
+		if name == "" {
+			name = config["volatile."+key+".name"]
+		}
+
+		if name == "" {
+			name = key
+		}
+
+		byName[name] = key
+	}
+
+	return byHwaddr, byName
+}
+
+// nicDevice is the device key behind one interface of the state. The hardware
+// address is the surest link, since the guest may rename an interface; the
+// name Incus gave it comes next; the interface name itself is what is left.
+func nicDevice(
+	ifname string,
+	iface incusapi.InstanceStateNetwork,
+	byHwaddr, byName map[string]string,
+) string {
+	if device, ok := byHwaddr[strings.ToLower(iface.Hwaddr)]; ok && iface.Hwaddr != "" {
+		return device
+	}
+
+	if device, ok := byName[ifname]; ok {
+		return device
+	}
+
+	return ifname
 }
 
 // addresses is every global address of one family the interface holds. Anything

--- a/ievent/enricher/state_test.go
+++ b/ievent/enricher/state_test.go
@@ -122,6 +122,50 @@ func TestPutInstance(t *testing.T) {
 			wantIPv4: nil,
 		},
 		{
+			// A profile may call the device anything; the guest still sees eth0.
+			// Incus records the guest name as volatile.<device>.name.
+			name: "a NIC whose device key differs from the guest interface name is found by its recorded name",
+			change: func(p *testlib.Project) {
+				inst := &p.Instances[0]
+				inst.ExpandedDevices["eth-1"] = inst.ExpandedDevices["eth0"]
+				delete(inst.ExpandedDevices, "eth0")
+				inst.ExpandedConfig["volatile.eth-1.name"] = "eth0"
+			},
+			running:  true,
+			wantNets: []string{"p/net0"},
+			wantIPv4: []string{"10.0.0.10"},
+		},
+		{
+			name: "a NIC whose device key differs from the guest interface name is found by its hardware address",
+			change: func(p *testlib.Project) {
+				inst := &p.Instances[0]
+				inst.ExpandedDevices["net0"] = inst.ExpandedDevices["eth0"]
+				delete(inst.ExpandedDevices, "eth0")
+				inst.ExpandedConfig["volatile.net0.hwaddr"] = "10:66:6A:00:00:01"
+
+				st := p.States[testlib.InstanceName(0)]
+				iface := st.Network["eth0"]
+				iface.Hwaddr = "10:66:6a:00:00:01"
+				st.Network["eth0"] = iface
+			},
+			running:  true,
+			wantNets: []string{"p/net0"},
+			wantIPv4: []string{"10.0.0.10"},
+		},
+		{
+			name: "a NIC that pins its own guest name is found by it",
+			change: func(p *testlib.Project) {
+				inst := &p.Instances[0]
+				nic := inst.ExpandedDevices["eth0"]
+				nic["name"] = "eth0"
+				inst.ExpandedDevices["incus-ovn"] = nic
+				delete(inst.ExpandedDevices, "eth0")
+			},
+			running:  true,
+			wantNets: []string{"p/net0"},
+			wantIPv4: []string{"10.0.0.10"},
+		},
+		{
 			name: "devices fall back to the instance's own when nothing is expanded",
 			change: func(p *testlib.Project) {
 				p.Instances[0].Devices = p.Instances[0].ExpandedDevices


### PR DESCRIPTION
## Problem

`interfaces()` in `ievent/enricher/state.go` looks the NIC up in `ExpandedDevices` under the interface name reported by the instance state (e.g. `eth0`). That only holds when the device key is `eth0`. A profile may call the device anything (`eth-1`, or the network's own name) while the guest still sees `eth0`; such instances get no `interfaces`, hence no A/PTR records, NXDOMAIN with the zone SOA in authority, and no log line.

## Where it was seen

3-node Incus 7.3 cluster, OVN networks. Every instance using a profile with a NIC device named `eth-1` was missing from ic-dns, while incus-compose stacks (device `eth0`) worked.

Before, with ic-dns from `develop`:

```
$ dig +short mgmt.default.incus
$ dig mgmt.default.incus | grep -E 'status|SOA'
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, ...
incus. ... SOA ...
```

After, built from this branch and run as an OCI instance:

```
$ dig +short mgmt.default.incus
10.146.11.6
```

## Fix

Incus records the link as `volatile.<device>.hwaddr` and `volatile.<device>.name` on the instance, and a device may pin `hwaddr`/`name` itself. `nicIndex` builds two maps from the NIC devices, `nicDevice` resolves an interface by hardware address first (the guest may rename an interface), then by recorded name, and falls back to the interface name itself, which keeps today's behaviour for a device that has never been started.

## Tests

Three new cases in `TestPutInstance`: recorded name, hardware address alone, device pinning its own name. All three fail on `develop` and pass with the patch. `go test ./ievent/...` is green.

No CHANGELOG entry, since ic-dns has not shipped in a release yet; happy to add one if you prefer.

Found while trying ic-dns on our cluster; happy to adjust naming or placement to match the package's conventions.
